### PR TITLE
Добавлены расчет статистики и API для получения расчетов.

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -56,6 +56,7 @@ collected_static
 
 # IDEs
 .idea
+.devcontainer
 
 settings_local.py
 files/static

--- a/backend/feeder/serializers.py
+++ b/backend/feeder/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import routers, serializers, viewsets
 
 from feeder import models
+from feeder.utils import StatisticType
 
 
 class DepartmentSerializer(serializers.ModelSerializer):
@@ -85,6 +86,20 @@ class SyncStatistic(serializers.Serializer):
     volunteers = SyncStatisticItem()
     departments = SyncStatisticItem()
     locations = SyncStatisticItem()
+
+
+class StatisticsRequestSerializer(serializers.Serializer):
+    date_from = serializers.DateField()
+    date_to = serializers.DateField()
+
+
+class StatisticsResponseSerializer(serializers.Serializer):
+    date = serializers.DateField()
+    type = serializers.ChoiceField(choices=[type.value for type in StatisticType])
+    is_vegan = serializers.BooleanField(allow_null=True)
+    meal_time = serializers.CharField(max_length=10, validators=[models.validate_meal_time])
+    amount = serializers.IntegerField(min_value=0)
+    kitchen_id = serializers.IntegerField(allow_null=True)
 
 
 class SimpleResponse(serializers.Serializer):

--- a/backend/feeder/urls.py
+++ b/backend/feeder/urls.py
@@ -20,8 +20,8 @@ urlpatterns = [
 
     path('', include(router.urls)),
     # path('update-balance', views.UpdateBalance.as_view()),
-    path('feed-transaction/bulk', views.FeedTransactionBulk.as_view()),
-    path('statistics', views.Statistics.as_view()),
+    path('feed-transaction/bulk', views.FeedTransactionBulk.as_view()), 
+    path('statistics/', views.Statistics.as_view()),
     path('notion-sync', views.SyncWithNotion.as_view()),
 ]
 


### PR DESCRIPTION
Примеры запроса:

- .../api/v1/statistics - статистика за текущий день (на момент запроса)
- .../api/v1/statistics/?date_from=2023-05-25 - статистика за период с 2023-05-25 по текущий день
- .../api/v1/statistics/?date_to=2023-05-26 - статистика за период с текущего дня по 2023-05-26
- .../api/v1/statistics/?date_from=2023-05-25&date_to=2023-05-26 - статистика за период с 2023-05-25 по 2023-05-26

Во всех случаях начало и конец периодов включены в расчет.

Параметры _date_from_ и _date_to_ необязательны. В случае их отсутствия оба параметра получают значение даты текущего дня и статистика будет посчитана и возвращена за текущий день. Если один из параметров пропущен, то он получает значение текущего дня. Значение каждого из параметров должно быть передано в формате YYYY-MM-DD. 

Если требуется сделать расчет на один день, то параметры _date_from_ и _date_to_ должны быть оба равны целевому дню.

Ответ приходит в виде массива данных по схеме:
<img width="325" alt="Screenshot 2023-05-26 at 12 28 52" src="https://github.com/Insomnia-IT/feed/assets/33791946/f4a5cbe3-b7ea-4e26-9b8d-4ddd73df1f40">
