### PR TITLE
#139 Быстрая синхронизация

### DIFF
--- a/backend/feeder/serializers.py
+++ b/backend/feeder/serializers.py
@@ -149,13 +149,15 @@ class StatisticsResponseSerializer(serializers.Serializer):
     amount = serializers.IntegerField(min_value=0)
     kitchen_id = serializers.IntegerField(allow_null=True)
 
+
 class SyncWithFeederRequestSerializer(serializers.Serializer):
     last_updated = serializers.DateTimeField(allow_null=True)
     transactions = FeedTransactionSerializer(many=True)
+    kitchen_id = serializers.IntegerField(allow_null=True)
 
 
 class SyncWithFeederResponseSerializer(serializers.Serializer):
-    last_updated = serializers.DateTimeField()
+    last_updated = serializers.DateTimeField(allow_null=True)
     transactions = FeedTransactionSerializer(many=True)
 
 

--- a/backend/feeder/serializers.py
+++ b/backend/feeder/serializers.py
@@ -149,6 +149,15 @@ class StatisticsResponseSerializer(serializers.Serializer):
     amount = serializers.IntegerField(min_value=0)
     kitchen_id = serializers.IntegerField(allow_null=True)
 
+class SyncWithFeederRequestSerializer(serializers.Serializer):
+    last_updated = serializers.DateTimeField(allow_null=True)
+    transactions = FeedTransactionSerializer(many=True)
+
+
+class SyncWithFeederResponseSerializer(serializers.Serializer):
+    last_updated = serializers.DateTimeField()
+    transactions = FeedTransactionSerializer(many=True)
+
 
 class SimpleResponse(serializers.Serializer):
     success = serializers.BooleanField()

--- a/backend/feeder/urls.py
+++ b/backend/feeder/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     path('', include(router.urls)),
     # path('update-balance', views.UpdateBalance.as_view()),
     path('feed-transaction/bulk', views.FeedTransactionBulk.as_view()), 
+    path('feed-transaction/sync', views.SyncWithFeeder.as_view()), 
     path('statistics/', views.Statistics.as_view()),
     path('notion-sync', views.SyncWithNotion.as_view()),
 ]

--- a/backend/feeder/views.py
+++ b/backend/feeder/views.py
@@ -201,7 +201,7 @@ class SyncWithFeeder(APIView):
     @extend_schema(
         request=serializers.SyncWithFeederRequestSerializer(),
         responses={
-            200: serializers.SyncWithFeederResponseSerializer(many=True)
+            200: serializers.SyncWithFeederResponseSerializer()
         },
     )
     

--- a/backend/feeder/views.py
+++ b/backend/feeder/views.py
@@ -63,6 +63,7 @@ class VolunteerFilter(django_filters.FilterSet):
     phone = django_filters.CharFilter(field_name="phone", lookup_expr='icontains')
     email = django_filters.CharFilter(field_name="email", lookup_expr='icontains')
     qr = django_filters.CharFilter(field_name="qr", lookup_expr='iexact')
+    updated_at__from = django_filters.IsoDateTimeFilter(field_name="updated_at", lookup_expr='gte')
 
     class Meta:
         model = models.Volunteer

--- a/packages/scanner/src/app-context.tsx
+++ b/packages/scanner/src/app-context.tsx
@@ -21,17 +21,19 @@ export interface IAppContext {
     resetColor: () => void;
     appError: string | null;
     setError: (err: string | null) => void;
-    setLastUpdated: (ts: number) => void;
+    setLastSyncStart: (ts: number) => void;
     setVolCount: (ts: number) => void;
     pin: string | null;
     setPin: (pin: string) => void;
     setAuth: (auth: boolean) => void;
-    lastUpdate: number | null;
+    lastSyncStart: number | null;
     volCount: number;
     mealTime: MealTime | null;
     setMealTime: (mealTime: MealTime) => void;
-    kitchenId: string | null;
+    kitchenId: number;
     isDev: boolean;
+    debugMode: string | null;
+    deoptimizedSync: string | null;
 }
 
 // @ts-ignore

--- a/packages/scanner/src/app.module.css
+++ b/packages/scanner/src/app.module.css
@@ -9,16 +9,16 @@ button {
 }
 
 .anon {
-    padding: 10px;
     position: absolute;
     bottom: 20vh;
+    padding: 10px;
 }
 
 .app {
     font-size: var(--fs);
 
     h2 {
-        margin: 15px 0 10px 0;
+        margin: 15px 0 10px;
         text-align: center;
     }
 
@@ -26,7 +26,7 @@ button {
         position: relative;
         width: 100vw;
         height: 100vh;
-        max-height: -webkit-fill-available;
+        max-height: fill-available;
 
         &.main {
             display: flex;
@@ -37,11 +37,11 @@ button {
         }
 
         &.history {
-            /*background-color: var(--c-yellow);*/
+            /* background-color: var(--c-yellow); */
         }
 
         &.stats {
-            /*background-color: var(--c-blue);*/
+            /* background-color: var(--c-blue); */
         }
     }
 }
@@ -51,8 +51,8 @@ button {
     flex-direction: column;
     justify-content: space-around;
     align-items: center;
-    font-size: 2em;
     height: 400px;
+    font-size: 2em;
 
     input {
         width: 90vw;

--- a/packages/scanner/src/app.tsx
+++ b/packages/scanner/src/app.tsx
@@ -99,7 +99,7 @@ const App: FC = () => {
             kitchenId,
             isDev
         }),
-        [pin, lastUpdate, volCount]
+        [pin, appError, lastUpdate, volCount, mealTime, kitchenId]
     );
 
     const viewContextValue: IViewContext = useMemo(

--- a/packages/scanner/src/app.tsx
+++ b/packages/scanner/src/app.tsx
@@ -42,6 +42,7 @@ const ErrorFallback: FC<FallbackProps> = ({ error, resetErrorBoundary }) => (
 
 const storedPin = localStorage.getItem('pin');
 const storedKitchenId = localStorage.getItem('kitchenId');
+const lastUpdatedLS = localStorage.getItem('lastUpdated');
 
 const App: FC = () => {
     const [appColor, setAppColor] = useState<AppColor | null>(null);
@@ -52,7 +53,7 @@ const App: FC = () => {
     const pinInputRef = useRef<HTMLInputElement | null>(null);
     const checkAuth = useCheckAuth(API_DOMAIN, setAuth);
     const appStyle = useMemo(() => ({ backgroundColor: Colors[appColor as AppColor] }), [appColor]);
-    const [lastUpdate, setLastUpdated] = useState<number | null>(null);
+    const [lastUpdate, setLastUpdated] = useState<number | null>(lastUpdatedLS ? +lastUpdatedLS : null);
     const [volCount, setVolCount] = useState<number>(0);
     const [currentView, setCurrentView] = useState<number>(0);
     const [kitchenId, setKitchenId] = useState<string | null>(storedKitchenId);

--- a/packages/scanner/src/common/colors.ts
+++ b/packages/scanner/src/common/colors.ts
@@ -1,9 +1,9 @@
 // @ts-ignore
 export type Colors = {
-    'red': '#ff0000';
-    'green': '#00ff00';
-    'yellow': '#fad900';
-    'blue': '#182bff';
-    'dark': '#333333';
-    'light': '#f5f5f5';
+    red: '#ff0000';
+    green: '#00ff00';
+    yellow: '#fad900';
+    blue: '#182bff';
+    dark: '#333333';
+    light: '#f5f5f5';
 };

--- a/packages/scanner/src/common/colors.ts
+++ b/packages/scanner/src/common/colors.ts
@@ -1,9 +1,9 @@
 // @ts-ignore
 export type Colors = {
-    red: '#ff0000';
-    green: '#00ff00';
-    yellow: '#fad900';
-    blue: '#182bff';
-    dark: '#333333';
-    light: '#f5f5f5';
+    'red': '#ff0000';
+    'green': '#00ff00';
+    'yellow': '#fad900';
+    'blue': '#182bff';
+    'dark': '#333333';
+    'light': '#f5f5f5';
 };

--- a/packages/scanner/src/components/btn-sync/btn-sync.module.css
+++ b/packages/scanner/src/components/btn-sync/btn-sync.module.css
@@ -33,7 +33,7 @@
         position: absolute;
         width: 0.45em;
         height: 0.45em;
-        background: #ffb110;
+        background: orange;
         border-radius: 50%;
     }
 }

--- a/packages/scanner/src/components/btn-sync/btn-sync.module.css
+++ b/packages/scanner/src/components/btn-sync/btn-sync.module.css
@@ -25,4 +25,15 @@
     svg {
         width: 2em;
     }
+
+    .deoptimizedIcon {
+        top: -0.2em;
+        right: -0.2em;
+        content: '';
+        position: absolute;
+        width: 0.45em;
+        height: 0.45em;
+        background: #ffb110;
+        border-radius: 50%;
+    }
 }

--- a/packages/scanner/src/components/btn-sync/btn-sync.tsx
+++ b/packages/scanner/src/components/btn-sync/btn-sync.tsx
@@ -35,14 +35,14 @@ export const BtnSync: React.FC = () => {
             // clearTimeout(timer);
             if (navigator.onLine) {
                 console.log('online, updating...');
-                void send();
+                void send({ lastUpdate });
             }
         };
 
         const timer = setInterval(sync, SYNC_INTERVAL);
 
         return () => clearInterval(timer);
-    }, [send]);
+    }, [send, lastUpdate]);
 
     const success = !error && updated;
 

--- a/packages/scanner/src/components/btn-sync/btn-sync.tsx
+++ b/packages/scanner/src/components/btn-sync/btn-sync.tsx
@@ -13,21 +13,21 @@ import css from './btn-sync.module.css';
 const SYNC_INTERVAL = 2 * 60 * 1000;
 
 export const BtnSync: React.FC = () => {
-    const { lastUpdate, pin, setAuth, setLastUpdated, setVolCount } = useContext(AppContext);
+    const { deoptimizedSync, lastSyncStart, pin, setAuth, setLastSyncStart, setVolCount } = useContext(AppContext);
     const { error, fetching, send, updated } = useSync(API_DOMAIN, pin, setAuth);
 
     const click = useCallback(() => {
-        void send({ lastUpdate });
-    }, [send, lastUpdate]);
+        void send({ lastSyncStart });
+    }, [send, lastSyncStart]);
 
     useEffect(() => {
         if (updated && !fetching) {
-            setLastUpdated(updated);
+            setLastSyncStart(updated);
             void db.volunteers.count().then((c) => {
                 setVolCount(c);
             });
         }
-    }, [fetching, setLastUpdated, setVolCount, updated]);
+    }, [fetching, setLastSyncStart, setVolCount, updated]);
 
     useEffect(() => {
         // TODO detect hanged requests
@@ -35,14 +35,14 @@ export const BtnSync: React.FC = () => {
             // clearTimeout(timer);
             if (navigator.onLine) {
                 console.log('online, updating...');
-                void send({ lastUpdate });
+                void send({ lastSyncStart });
             }
         };
 
         const timer = setInterval(sync, SYNC_INTERVAL);
 
         return () => clearInterval(timer);
-    }, [send, lastUpdate]);
+    }, [send, lastSyncStart]);
 
     const success = !error && updated;
 
@@ -52,6 +52,7 @@ export const BtnSync: React.FC = () => {
             onClick={fetching ? nop : click}
             disabled={fetching}
         >
+            {deoptimizedSync === '1' && <div className={css.deoptimizedIcon}></div>}
             <Refresh />
         </button>
     );

--- a/packages/scanner/src/components/btn-sync/btn-sync.tsx
+++ b/packages/scanner/src/components/btn-sync/btn-sync.tsx
@@ -13,14 +13,12 @@ import css from './btn-sync.module.css';
 const SYNC_INTERVAL = 2 * 60 * 1000;
 
 export const BtnSync: React.FC = () => {
-    const { pin, setAuth, setLastUpdated, setVolCount } = useContext(AppContext);
+    const { lastUpdate, pin, setAuth, setLastUpdated, setVolCount } = useContext(AppContext);
     const { error, fetching, send, updated } = useSync(API_DOMAIN, pin, setAuth);
 
-    console.log({ error, fetching, updated });
-
     const click = useCallback(() => {
-        void send();
-    }, [send]);
+        void send({ lastUpdate });
+    }, [send, lastUpdate]);
 
     useEffect(() => {
         if (updated && !fetching) {

--- a/packages/scanner/src/components/history/history-table/history-table.module.css
+++ b/packages/scanner/src/components/history/history-table/history-table.module.css
@@ -8,26 +8,26 @@
         position: sticky;
         top: 0;
         background-color: var(--c-dark);
-        color: #fff;
+        color: rgb(255 255 255);
 
         th {
             padding: 10px;
+            border: 1px solid rgb(208 208 208);
+            border-top: none;
             font-weight: 500;
             text-align: left;
-            border: 1px solid #d0d0d0;
-            border-top: none;
         }
     }
 
-tbody {
-    tr:nth-child(even) {
-        background-color: var(--c-light);
-    }
+    tbody {
+        tr:nth-child(even) {
+            background-color: var(--c-light);
+        }
 
         td {
             padding: 10px;
+            border: 1px solid rgb(208 208 208);
             text-align: left;
-            border: 1px solid #d0d0d0;
         }
     }
 }

--- a/packages/scanner/src/components/history/history.module.css
+++ b/packages/scanner/src/components/history/history.module.css
@@ -1,11 +1,11 @@
 .history {
     position: relative;
-    height: calc(100vh - var(--header-h-mobile));
     overflow: auto;
+    height: calc(100vh - var(--header-h-mobile));
 }
 
 @media --desktop {
     .history {
         height: calc(100vh - var(--header-h-mobile));
-}
+    }
 }

--- a/packages/scanner/src/components/meal-time-select/meal-time-select.module.css
+++ b/packages/scanner/src/components/meal-time-select/meal-time-select.module.css
@@ -1,11 +1,11 @@
 .mealTimeSelectBlock {
-    padding: 15px;
-    margin: auto;
     display: flex;
     flex-direction: column;
+    gap: 15px;
     justify-content: center;
     align-items: center;
-    gap: 15px;
+    margin: auto;
+    padding: 15px;
 
     button {
         width: 50vw;

--- a/packages/scanner/src/components/misc/misc.module.css
+++ b/packages/scanner/src/components/misc/misc.module.css
@@ -14,8 +14,8 @@
 
 .anoncard {
     button {
-        padding: 1em;
         width: 50vw;
+        padding: 1em;
     }
 }
 

--- a/packages/scanner/src/components/mock-trans/mock-trans.module.css
+++ b/packages/scanner/src/components/mock-trans/mock-trans.module.css
@@ -1,9 +1,9 @@
 .mockBlock {
+    position: absolute;
+    right: 2vw;
+    bottom: 10vh;
     display: flex;
     gap: 5px;
-    position: absolute;
-    bottom: 10vh;
-    right: 2vw;
 
     button {
         font-size: 0.8em;

--- a/packages/scanner/src/components/post-scan/post-scan-anon/post-scan-anon.tsx
+++ b/packages/scanner/src/components/post-scan/post-scan-anon/post-scan-anon.tsx
@@ -9,9 +9,9 @@ import { useFeedVol } from '../post-scan.utils';
 export const PostScanAnon: FC<{
     closeFeed: () => void;
 }> = ({ closeFeed }) => {
-    const { mealTime, setColor } = useContext(AppContext);
+    const { kitchenId, mealTime, setColor } = useContext(AppContext);
 
-    const [doFeed] = useFeedVol(undefined, mealTime, closeFeed);
+    const [doFeed] = useFeedVol(undefined, mealTime, closeFeed, kitchenId);
 
     useEffect(() => setColor(AppColor.GREEN), []);
 

--- a/packages/scanner/src/components/post-scan/post-scan-group-badge/post-scan-group-badge-misc/post-scan-group-badge-misc.module.css
+++ b/packages/scanner/src/components/post-scan/post-scan-group-badge/post-scan-group-badge-misc/post-scan-group-badge-misc.module.css
@@ -1,19 +1,19 @@
 .groupBadgeInfo {
-	display: flex;
-	flex-direction: column;
-	gap: 0.5em;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5em;
 
-	.total {
-			font-weight: bold;
-	}
+    .total {
+        font-weight: bold;
+    }
 
-	.fact {
-			font-size: 0.75em;
-	}
+    .fact {
+        font-size: 0.75em;
+    }
 }
 
 .feedTypeInfo {
-	display: flex;
+    display: flex;
     flex-direction: row;
     gap: 2em;
     justify-content: space-between;
@@ -34,25 +34,25 @@
 }
 
 .volunteerList {
-	display: flex;
-	flex-direction: column;
-	gap: 0.25em;
-	font-size: 0.6em;
-	align-items: end;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25em;
+    align-items: end;
+    font-size: 0.6em;
 
-	.title {
-		&.red {
-			background-color: var(--c-red);
-		}
+    .title {
+        &.red {
+            background-color: var(--c-red);
+        }
 
-		&.green {
-			background-color: var(--c-green);
-		}
-	}
+        &.green {
+            background-color: var(--c-green);
+        }
+    }
 
-	.volonteerListItem {
-		display: flex;
-		flex-direction: row;
-		gap: 5em;
-	}
+    .volonteerListItem {
+        display: flex;
+        flex-direction: row;
+        gap: 5em;
+    }
 }

--- a/packages/scanner/src/components/post-scan/post-scan-group-badge/post-scan-group-badge.tsx
+++ b/packages/scanner/src/components/post-scan/post-scan-group-badge/post-scan-group-badge.tsx
@@ -56,16 +56,20 @@ export const PostScanGroupBadge: FC<{
     const incFeedAsync = useCallback(
         async (vols: Array<ValidatedVol>, error: boolean) =>
             await Promise.all(
-                vols.map((vol) =>
-                    dbIncFeed(
-                        vol,
-                        mealTime!,
-                        undefined,
+                vols.map((vol) => {
+                    const log =
                         !error && vol.msg.length === 0
                             ? undefined
-                            : { error, reason: vol.msg.concat('Групповое питание').join(', ') }
-                    )
-                )
+                            : { error, reason: vol.msg.concat('Групповое питание').join(', ') };
+
+                    return dbIncFeed({
+                        vol,
+                        mealTime: mealTime!,
+                        isVegan: undefined,
+                        log,
+                        kitchenId
+                    });
+                })
             ),
         []
     );
@@ -87,7 +91,7 @@ export const PostScanGroupBadge: FC<{
 
         // pass each vol through validation and combine result
         const validatedVols = vols.map((vol) => {
-            return { ...vol, ...validateVol(vol, vol.transactions!, kitchenId!, mealTime!, true) };
+            return { ...vol, ...validateVol(vol, vol.transactions!, kitchenId, mealTime!, true) };
         });
 
         setValidationGroups({

--- a/packages/scanner/src/components/post-scan/post-scan-vol/post-scan-vol.tsx
+++ b/packages/scanner/src/components/post-scan/post-scan-vol/post-scan-vol.tsx
@@ -17,13 +17,13 @@ export const PostScanVol: FC<{
 
     const { kitchenId, mealTime, setColor } = useContext(AppContext);
 
-    const [doFeed, doNotFeed] = useFeedVol(vol, mealTime, closeFeed);
+    const [doFeed, doNotFeed] = useFeedVol(vol, mealTime, closeFeed, kitchenId);
 
     if (!volTransactions) {
         return <ErrorMsg close={closeFeed} doNotFeed={doNotFeed} msg={`Бейдж не найден: ${qrcode}`} />;
     }
 
-    const { isRed, msg } = validateVol(vol, volTransactions, kitchenId!, mealTime!, false);
+    const { isRed, msg } = validateVol(vol, volTransactions, kitchenId, mealTime!, false);
 
     if (msg.length > 0) {
         if (isRed) {

--- a/packages/scanner/src/components/post-scan/post-scan.utils.ts
+++ b/packages/scanner/src/components/post-scan/post-scan.utils.ts
@@ -9,14 +9,14 @@ import { getMealTimeText } from '~/lib/utils';
 export const validateVol = (
     vol: Volunteer,
     volTransactions: Array<Transaction>,
-    kitchenId: string,
+    kitchenId: number,
     mealTime: MealTime,
     isGroupScan: boolean
 ): { msg: Array<string>; isRed: boolean } => {
     const msg: Array<string> = [];
     let isRed = false;
 
-    if (vol.feed_type !== FeedType.Child && vol.kitchen.toString() !== kitchenId) {
+    if (vol.feed_type !== FeedType.Child && vol.kitchen.toString() !== kitchenId.toString()) {
         msg.push(`Кормится на кухне №${vol.kitchen}`);
     }
     if (!vol.is_active) {
@@ -73,19 +73,24 @@ export const validateVol = (
 
 export const getTodayStart = () => dayjs().subtract(7, 'h').startOf('day').add(7, 'h').unix();
 
-export const useFeedVol = (vol: Volunteer | undefined, mealTime: MealTime | null, closeFeed: () => void) => {
+export const useFeedVol = (
+    vol: Volunteer | undefined,
+    mealTime: MealTime | null,
+    closeFeed: () => void,
+    kitchenId: number
+) => {
     const feed = useCallback(
         async (isVegan: boolean | undefined, log?: { error: boolean; reason: string }) => {
             if (mealTime) {
                 try {
-                    await dbIncFeed(vol, mealTime, isVegan, log);
+                    await dbIncFeed({ vol, mealTime, isVegan, log, kitchenId });
                     closeFeed();
                 } catch (e) {
                     console.error(e);
                 }
             }
         },
-        [closeFeed, vol]
+        [closeFeed, mealTime, vol]
     );
 
     return [

--- a/packages/scanner/src/components/qr-scan-simulator/qr-scan-simulator.module.css
+++ b/packages/scanner/src/components/qr-scan-simulator/qr-scan-simulator.module.css
@@ -1,9 +1,9 @@
 .scanSimulatorBlock {
-    display: flex;
-    gap: 5px;
     position: absolute;
     top: 20vh;
     z-index: 1000;
+    display: flex;
+    gap: 5px;
 
     button {
         font-size: 0.8em;
@@ -14,7 +14,7 @@
     }
 
     select {
-        width: 100px;
         align-self: center;
+        width: 100px;
     }
 }

--- a/packages/scanner/src/components/qr-scan/qr-scan.module.css
+++ b/packages/scanner/src/components/qr-scan/qr-scan.module.css
@@ -9,7 +9,7 @@
     display: flex;
     width: 100vw;
     height: 100vh;
-    max-height: -webkit-fill-available;
+    max-height: fill-available;
 
     .flash {
         position: absolute;

--- a/packages/scanner/src/components/screen-header/screen-header.module.css
+++ b/packages/scanner/src/components/screen-header/screen-header.module.css
@@ -1,35 +1,37 @@
 .header {
-    height: var(--header-h-mobile);
-    top: 0px;
+    top: 0;
+    z-index: 1000;
     display: grid;
     grid-template-columns: 50px 1fr 50px;
     align-items: center;
-    background: #fff;
-    z-index: 1000;
+    height: var(--header-h-mobile);
+    background: rgb(255 255 255);
 
     .button {
-        line-height: 0;
         padding: 0;
-        border-radius: 50%;
         border: none;
+        border-radius: 50%;
         background: none;
+        line-height: 0;
         transition: background 0.05s;
 
         &:active {
-            background-color: #e7e7e7;
+            background-color: rgb(231 231 231);
         }
     }
 
     h1 {
-        margin: auto;
         display: block;
-        font-size: 1.75rem;
+        margin: auto;
         font-weight: 500;
+        font-size: 1.75rem;
     }
 }
+
 @media --desktop {
     .header {
         height: var(--header-h-desktop);
+
         h1 {
             font-size: 3rem;
         }

--- a/packages/scanner/src/components/stats/stats-date-picker/stats-date-picker.module.css
+++ b/packages/scanner/src/components/stats/stats-date-picker/stats-date-picker.module.css
@@ -1,32 +1,33 @@
 .datePicker {
     display: flex;
-    align-items: center;
     gap: 2px;
+    align-items: center;
 
     .date {
         font-size: 0.75em;
     }
 
     .button {
-        line-height: 0;
         padding: 0;
-        border: 1px solid #d0d0d0;
+        border: 1px solid rgb(208 208 208);
         border-radius: 5px;
-
-        .svg {
-            height: 30px;
-            width: 30px
-        }
+        line-height: 0;
 
         @media --desktop {
             .svg {
-                height: 40px;
                 width: 40px;
+                height: 40px;
             }
         }
 
-        &:disabled, &:active {
-             opacity: 0.5;
-        };
+        .svg {
+            width: 30px;
+            height: 30px;
+        }
+
+        &:disabled,
+        &:active {
+            opacity: 0.5;
+        }
     }
 }

--- a/packages/scanner/src/components/stats/stats-table/stats-table.module.css
+++ b/packages/scanner/src/components/stats/stats-table/stats-table.module.css
@@ -1,9 +1,9 @@
 .table {
     width: 100%;
     border-collapse: collapse;
+    color: var(--c-dark);
     table-layout: fixed;
     font-size: 0.9em;
-    color: var(--c-dark);
     transition: opacity 0.1s;
 
     thead {
@@ -11,24 +11,24 @@
 
         th {
             padding: 10px;
+            border: 1px solid rgb(208 208 208);
             font-weight: 500;
             text-align: center;
-            border: 1px solid #d0d0d0;
         }
     }
 
     tbody {
         th {
-            font-weight: 500;
             padding: 10px;
+            border: 1px solid rgb(208 208 208);
+            font-weight: 500;
             text-align: left;
-            border: 1px solid #d0d0d0;
         }
 
         td {
             padding: 10px;
+            border: 1px solid rgb(208 208 208);
             text-align: center;
-            border: 1px solid #d0d0d0;
         }
     }
 }

--- a/packages/scanner/src/components/stats/stats.module.css
+++ b/packages/scanner/src/components/stats/stats.module.css
@@ -1,8 +1,8 @@
 .statsInfoWrapper {
-    padding: 5px 5px 0 5px;
     display: flex;
     justify-content: space-between;
     align-items: start;
+    padding: 5px 5px 0;
 }
 
 .loading {

--- a/packages/scanner/src/lib/mock.ts
+++ b/packages/scanner/src/lib/mock.ts
@@ -14,13 +14,15 @@ const createTestTrans = (type: 'now' | 'rnd', mealTime: MealTime): Transaction =
         ts = dayjs().startOf('day').add(rndInt(7, 31), 'h');
     }
     ts = ts.unix();
-    const vol_id = rndInt(0, 600);
+    const vol_id = rndInt(1, 600);
+    const kitchen = Number(localStorage.getItem('kitchenId'));
 
     return {
         vol_id,
         amount: 1,
         ts,
         ulid: ulid(ts),
+        kitchen,
         mealTime: mealTime,
         is_new: true,
         is_vegan: rndInt(0, 1) ? true : false

--- a/packages/scanner/src/lib/utils.ts
+++ b/packages/scanner/src/lib/utils.ts
@@ -36,3 +36,15 @@ const mealTimes = {
 export const getMealTimeText = (mealTime: string): string => {
     return mealTimes[mealTime] || '';
 };
+
+/*** Функция для генерации строки query params из плоского объекта */
+export const queryParamsFromObject = (objParams: any): string | null => {
+    return typeof objParams === 'object'
+        ? Object.entries(objParams).reduce((acc, curr, index) => {
+              if (index > 0) {
+                  acc = acc + '&';
+              }
+              return acc + `${curr[0]}=${curr[1]}`;
+          }, '?')
+        : null;
+};

--- a/packages/scanner/src/lib/utils.ts
+++ b/packages/scanner/src/lib/utils.ts
@@ -36,15 +36,3 @@ const mealTimes = {
 export const getMealTimeText = (mealTime: string): string => {
     return mealTimes[mealTime] || '';
 };
-
-/*** Функция для генерации строки query params из плоского объекта */
-export const queryParamsFromObject = (objParams: any): string | null => {
-    return typeof objParams === 'object'
-        ? Object.entries(objParams).reduce((acc, curr, index) => {
-              if (index > 0) {
-                  acc = acc + '&';
-              }
-              return acc + `${curr[0]}=${curr[1]}`;
-          }, '?')
-        : null;
-};

--- a/packages/scanner/src/request/use-get-group-badges.ts
+++ b/packages/scanner/src/request/use-get-group-badges.ts
@@ -10,69 +10,66 @@ export const useGetGroupBadges = (baseUrl: string, pin: string | null, setAuth: 
     const [updated, setUpdated] = useState<any>(null);
     const [fetching, setFetching] = useState<any>(false);
 
-    const send = useCallback(() => {
-        if (fetching) {
-            return Promise.resolve(false);
-        }
+    const send = useCallback(
+        (filters) => {
+            if (fetching) {
+                return Promise.resolve(false);
+            }
 
-        setFetching(true);
+            setFetching(true);
 
-        return new Promise((res, rej) => {
-            axios
-                .get(`${baseUrl}/group-badges/`, {
-                    headers: {
-                        Authorization: `K-PIN-CODE ${pin}`
-                    }
-                })
-                .then(async ({ data: { results } }) => {
-                    setFetching(false);
+            return new Promise((res, rej) => {
+                axios
+                    .get(`${baseUrl}/group-badges/`, {
+                        headers: {
+                            Authorization: `K-PIN-CODE ${pin}`
+                        },
+                        params: filters
+                    })
+                    .then(async ({ data: { results } }) => {
+                        setFetching(false);
 
-                    try {
-                        await db.groupBadges.clear();
-                    } catch (e) {
-                        rej(e);
-                        return false;
-                    }
-
-                    const qrs = {};
-                    const ids = {};
-                    for (const v of results as Array<GroupBadge>) {
-                        if (ids[v.id]) {
-                            console.log(ids[v.id], v);
-                        } else {
-                            ids[v.id] = v;
+                        const qrs = {};
+                        const ids = {};
+                        for (const v of results as Array<GroupBadge>) {
+                            if (ids[v.id]) {
+                                console.log(ids[v.id], v);
+                            } else {
+                                ids[v.id] = v;
+                            }
+                            if (qrs[v.qr]) {
+                                console.log(qrs[v.qr], v);
+                            } else {
+                                qrs[v.qr] = v;
+                            }
                         }
-                        if (qrs[v.qr]) {
-                            console.log(qrs[v.qr], v);
-                        } else {
-                            qrs[v.qr] = v;
-                        }
-                    }
 
-                    try {
-                        await db.groupBadges.bulkAdd(results as Array<GroupBadge>);
-                    } catch (e) {
-                        console.error(e);
+                        try {
+                            await db.groupBadges.bulkPut(results as Array<GroupBadge>);
+                        } catch (e) {
+                            console.error(e);
+                            rej(e);
+                            return false;
+                        }
+                        setUpdated(+new Date());
+                        res(true);
+                        return true;
+                    })
+                    .catch((e) => {
+                        setFetching(false);
+                        if (e?.response?.status === 401) {
+                            rej(false);
+                            setAuth(false);
+                            return false;
+                        }
+                        setError(e);
                         rej(e);
-                        return false;
-                    }
-                    setUpdated(+new Date());
-                    res(true);
-                    return true;
-                })
-                .catch((e) => {
-                    setFetching(false);
-                    if (e?.response?.status === 401) {
-                        rej(false);
-                        setAuth(false);
-                        return false;
-                    }
-                    setError(e);
-                    rej(e);
-                    return e;
-                });
-        });
-    }, [baseUrl, error, fetching, pin, setAuth]);
+                        return e;
+                    });
+            });
+        },
+        [baseUrl, error, fetching, pin, setAuth]
+    );
 
     return <ApiHook>useMemo(
         () => ({

--- a/packages/scanner/src/request/use-get-trans.ts
+++ b/packages/scanner/src/request/use-get-trans.ts
@@ -48,14 +48,15 @@ export const useGetTrans = (baseUrl: string, pin: string | null, setAuth: (auth:
                     try {
                         const serverTransactions = results as Array<ServerTransaction>;
                         const transactions = serverTransactions.map(
-                            ({ amount, dtime, is_vegan, meal_time, ulid, volunteer }) => ({
+                            ({ amount, dtime, is_vegan, kitchen, meal_time, ulid, volunteer }) => ({
                                 vol_id: volunteer,
                                 is_vegan,
                                 mealTime: meal_time,
                                 ulid,
                                 amount,
                                 ts: Math.floor(new Date(dtime).valueOf() / 1000),
-                                is_new: false
+                                is_new: false,
+                                kitchen
                             })
                         );
 

--- a/packages/scanner/src/request/use-get-vols.ts
+++ b/packages/scanner/src/request/use-get-vols.ts
@@ -4,77 +4,76 @@ import axios from 'axios';
 import type { ApiHook } from '~/request/lib';
 import type { Volunteer } from '~/db';
 import { db } from '~/db';
+import { queryParamsFromObject } from '~/lib/utils';
 
 export const useGetVols = (baseUrl: string, pin: string | null, setAuth: (auth: boolean) => void): ApiHook => {
     const [error, setError] = useState<any>(null);
     const [updated, setUpdated] = useState<any>(null);
     const [fetching, setFetching] = useState<any>(false);
 
-    const send = useCallback(() => {
-        if (fetching) {
-            return Promise.resolve(false);
-        }
+    const send = useCallback(
+        (filters) => {
+            if (fetching) {
+                return Promise.resolve(false);
+            }
 
-        setFetching(true);
+            setFetching(true);
 
-        return new Promise((res, rej) => {
-            axios
-                .get(`${baseUrl}/volunteers/?limit=10000`, {
-                    headers: {
-                        Authorization: `K-PIN-CODE ${pin}`
-                    }
-                })
-                .then(async ({ data: { results } }) => {
-                    setFetching(false);
+            const filtersString = queryParamsFromObject(filters);
 
-                    try {
-                        await db.volunteers.clear();
-                    } catch (e) {
-                        rej(e);
-                        return false;
-                    }
-
-                    const qrs = {};
-                    const ids = {};
-                    for (const v of results as Array<Volunteer>) {
-                        if (ids[v.id]) {
-                            console.log(ids[v.id], v);
-                        } else {
-                            ids[v.id] = v;
+            return new Promise((res, rej) => {
+                axios
+                    .get(`${baseUrl}/volunteers/${filtersString}`, {
+                        headers: {
+                            Authorization: `K-PIN-CODE ${pin}`
                         }
-                        if (qrs[v.qr]) {
-                            console.log(qrs[v.qr], v);
-                        } else {
-                            qrs[v.qr] = v;
+                    })
+                    .then(async ({ data: { results } }) => {
+                        setFetching(false);
+
+                        const qrs = {};
+                        const ids = {};
+                        for (const v of results as Array<Volunteer>) {
+                            if (ids[v.id]) {
+                                console.log(ids[v.id], v);
+                            } else {
+                                ids[v.id] = v;
+                            }
+                            if (qrs[v.qr]) {
+                                console.log(qrs[v.qr], v);
+                            } else {
+                                qrs[v.qr] = v;
+                            }
                         }
-                    }
 
-                    const volunteers = (results as Array<Volunteer>).filter(({ qr }) => qr);
+                        const volunteers = (results as Array<Volunteer>).filter(({ qr }) => qr);
 
-                    try {
-                        await db.volunteers.bulkAdd(volunteers);
-                    } catch (e) {
-                        console.error(e);
+                        try {
+                            await db.volunteers.bulkPut(volunteers);
+                        } catch (e) {
+                            console.error(e);
+                            rej(e);
+                            return false;
+                        }
+                        setUpdated(+new Date());
+                        res(true);
+                        return true;
+                    })
+                    .catch((e) => {
+                        setFetching(false);
+                        if (e?.response?.status === 401) {
+                            rej(false);
+                            setAuth(false);
+                            return false;
+                        }
+                        setError(e);
                         rej(e);
-                        return false;
-                    }
-                    setUpdated(+new Date());
-                    res(true);
-                    return true;
-                })
-                .catch((e) => {
-                    setFetching(false);
-                    if (e?.response?.status === 401) {
-                        rej(false);
-                        setAuth(false);
-                        return false;
-                    }
-                    setError(e);
-                    rej(e);
-                    return e;
-                });
-        });
-    }, [baseUrl, error, fetching, pin, setAuth]);
+                        return e;
+                    });
+            });
+        },
+        [baseUrl, error, fetching, pin, setAuth]
+    );
 
     return <ApiHook>useMemo(
         () => ({

--- a/packages/scanner/src/request/use-get-vols.ts
+++ b/packages/scanner/src/request/use-get-vols.ts
@@ -4,7 +4,6 @@ import axios from 'axios';
 import type { ApiHook } from '~/request/lib';
 import type { Volunteer } from '~/db';
 import { db } from '~/db';
-import { queryParamsFromObject } from '~/lib/utils';
 
 export const useGetVols = (baseUrl: string, pin: string | null, setAuth: (auth: boolean) => void): ApiHook => {
     const [error, setError] = useState<any>(null);
@@ -19,14 +18,13 @@ export const useGetVols = (baseUrl: string, pin: string | null, setAuth: (auth: 
 
             setFetching(true);
 
-            const filtersString = queryParamsFromObject(filters);
-
             return new Promise((res, rej) => {
                 axios
-                    .get(`${baseUrl}/volunteers/${filtersString}`, {
+                    .get(`${baseUrl}/volunteers`, {
                         headers: {
                             Authorization: `K-PIN-CODE ${pin}`
-                        }
+                        },
+                        params: filters
                     })
                     .then(async ({ data: { results } }) => {
                         setFetching(false);

--- a/packages/scanner/src/request/use-send-trans.ts
+++ b/packages/scanner/src/request/use-send-trans.ts
@@ -11,8 +11,6 @@ export const useSendTrans = (baseUrl: string, pin: string | null, setAuth: (auth
     const [updated, setUpdated] = useState<any>(null);
     const [fetching, setFetching] = useState<any>(false);
 
-    console.log({ trans });
-
     const send = useCallback(() => {
         if (trans?.length === 0) {
             return Promise.resolve(true);
@@ -22,10 +20,9 @@ export const useSendTrans = (baseUrl: string, pin: string | null, setAuth: (auth
             return Promise.resolve(false);
         }
 
-        const kitchen = Number(localStorage.getItem('kitchenId'));
         const data = (trans || [])
             .filter(({ is_new }) => is_new)
-            .map(({ amount, is_vegan, mealTime, reason, ts, ulid, vol_id }) => ({
+            .map(({ amount, is_vegan, kitchen, mealTime, reason, ts, ulid, vol_id }) => ({
                 volunteer: vol_id,
                 is_vegan,
                 amount,

--- a/packages/scanner/src/request/use-sync-trans.ts
+++ b/packages/scanner/src/request/use-sync-trans.ts
@@ -1,0 +1,118 @@
+import { useCallback, useMemo, useState } from 'react';
+import axios, { AxiosError } from 'axios';
+import dayjs from 'dayjs';
+import type { IndexableType } from 'dexie';
+
+import type { ApiHook } from '~/request/lib';
+import { db } from '~/db';
+import type { ServerTransaction, Transaction } from '~/db';
+
+export const useSyncTransactions = (baseUrl: string, pin: string | null, setAuth: (auth: boolean) => void): ApiHook => {
+    const [error, setError] = useState<any>(null);
+    const [updated, setUpdated] = useState<any>(null);
+    const [fetching, setFetching] = useState<any>(false);
+
+    const send = useCallback(async () => {
+        if (fetching) {
+            return Promise.resolve(false);
+        }
+
+        let lastTransactionsSync = localStorage.getItem('lastTransactionsSync');
+
+        if (!lastTransactionsSync) {
+            lastTransactionsSync = dayjs().startOf('day').subtract(1, 'day').add(7, 'hours').toISOString();
+        }
+
+        setFetching(true);
+
+        try {
+            const transactions = await getNewClientTransactions();
+
+            const response = await axios.post<{ last_updated: string; transactions: Array<ServerTransaction> }>(
+                `${baseUrl}/feed-transaction/sync`,
+                {
+                    last_updated: lastTransactionsSync,
+                    transactions: transactions
+                },
+                {
+                    headers: {
+                        Authorization: `K-PIN-CODE ${pin}`
+                    }
+                }
+            );
+
+            await updateArrayTransactions(transactions, { is_new: false });
+            await putNewServerTransactions(response.data.transactions);
+            await deleteOutdatedTransactions();
+
+            localStorage.setItem('lastTransactionsSync', response.data.last_updated);
+
+            setUpdated(+new Date());
+            return;
+        } catch (e) {
+            if (e instanceof AxiosError && e?.response?.status === 401) {
+                setAuth(false);
+                return false;
+            }
+
+            setError(e);
+            return e;
+        } finally {
+            setFetching(false);
+        }
+    }, [baseUrl, fetching, pin, setAuth]);
+
+    return <ApiHook>useMemo(
+        () => ({
+            fetching,
+            error,
+            updated,
+            send
+        }),
+        [error, fetching, send, updated]
+    );
+};
+
+const getNewClientTransactions = async () => {
+    const trans = await db.transactions.toArray();
+
+    const kitchen = Number(localStorage.getItem('kitchenId'));
+    return (trans || [])
+        .filter(({ is_new }) => is_new)
+        .map(({ amount, is_vegan, mealTime, reason, ts, ulid, vol_id }) => ({
+            volunteer: vol_id,
+            is_vegan,
+            amount,
+            dtime: typeof ts === 'number' ? new Date(ts * 1000).toISOString() : ts,
+            ulid,
+            meal_time: mealTime,
+            kitchen,
+            reason
+        }));
+};
+
+const updateArrayTransactions = async (transactions, changes): Promise<void> => {
+    for (const transaction of transactions) {
+        await db.transactions.update(transaction.ulid, changes);
+    }
+};
+
+const putNewServerTransactions = async (data): Promise<IndexableType> => {
+    const serverTransactions = data as Array<ServerTransaction>;
+    const transactions = serverTransactions.map(({ amount, dtime, is_vegan, meal_time, ulid, volunteer }) => ({
+        vol_id: volunteer,
+        is_vegan,
+        mealTime: meal_time,
+        ulid,
+        amount,
+        ts: Math.floor(new Date(dtime).valueOf() / 1000),
+        is_new: false
+    }));
+
+    return db.transactions.bulkPut(transactions);
+};
+
+const deleteOutdatedTransactions = async (): Promise<Array<Transaction>> => {
+    const yesterdayTS = dayjs().startOf('day').subtract(1, 'day').add(7, 'hours').unix();
+    return db.transactions.where('ts').below(yesterdayTS).toArray();
+};

--- a/packages/scanner/src/request/use-sync.ts
+++ b/packages/scanner/src/request/use-sync.ts
@@ -1,42 +1,45 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useContext, useMemo, useState } from 'react';
 
 import { useGetVols } from '~/request/use-get-vols';
-import { useSendTrans } from '~/request/use-send-trans';
-import { useGetTrans } from '~/request/use-get-trans';
 import { useSyncTransactions } from '~/request/use-sync-trans';
+import { AppContext } from '~/app-context';
+import { useGetTrans } from '~/request/use-get-trans';
+import { useSendTrans } from '~/request/use-send-trans';
+import { db } from '~/db';
 
 import { useGetGroupBadges } from './use-get-group-badges';
 import type { ApiHook } from './lib';
 
 export const useSync = (baseUrl: string, pin: string | null, setAuth: (auth: boolean) => void): ApiHook => {
+    const { deoptimizedSync } = useContext(AppContext);
+
     const [error, setError] = useState<any>(null);
     const [updated, setUpdated] = useState<any>(null);
     const [fetching, setFetching] = useState<any>(false);
 
-    const {
-        // error: volsError,
-        fetching: volsFetching,
-        send: volsSend
-        // updated: volsUpdated
-    } = useGetVols(baseUrl, pin, setAuth);
+    const { fetching: sendTransFetching, send: sendTransSend } = useSendTrans(baseUrl, pin, setAuth);
 
-    const {
-        // error: volsError,
-        fetching: groupBadgesFetching,
-        send: groupBadgesSend
-        // updated: volsUpdated
-    } = useGetGroupBadges(baseUrl, pin, setAuth);
+    const { fetching: getTransFetching, send: getTransSend } = useGetTrans(baseUrl, pin, setAuth);
 
-    const {
-        // error: volsError,
-        fetching: syncTransactionsFetching,
-        send: syncTransactionsSend
-        // updated: volsUpdated
-    } = useSyncTransactions(baseUrl, pin, setAuth);
+    const { fetching: volsFetching, send: volsSend } = useGetVols(baseUrl, pin, setAuth);
+
+    const { fetching: groupBadgesFetching, send: groupBadgesSend } = useGetGroupBadges(baseUrl, pin, setAuth);
+
+    const { fetching: syncTransactionsFetching, send: syncTransactionsSend } = useSyncTransactions(
+        baseUrl,
+        pin,
+        setAuth
+    );
 
     const send = useCallback(
-        ({ lastUpdate }) => {
-            if (volsFetching || syncTransactionsFetching) {
+        ({ lastSyncStart }) => {
+            if (
+                volsFetching ||
+                syncTransactionsFetching ||
+                groupBadgesFetching ||
+                getTransFetching ||
+                sendTransFetching
+            ) {
                 return;
             }
 
@@ -60,16 +63,49 @@ export const useSync = (baseUrl: string, pin: string | null, setAuth: (auth: boo
                 };
 
                 try {
-                    await volsSend({ updated_at__from: new Date(lastUpdate).toISOString(), limit: '10000' });
-                    await syncTransactionsSend();
-                    await groupBadgesSend();
+                    console.time('Время синхронизации');
+                    if (deoptimizedSync === '1') {
+                        // TODO: Remove after test
+                        console.log('%c Старый алгоритм ', 'background: #ffb110;');
+                        await sendTransSend();
+                        await db.volunteers.clear();
+                        await volsSend({ limit: '10000' });
+                        await db.groupBadges.clear();
+                        await groupBadgesSend();
+                        await getTransSend();
+                    } else {
+                        console.log('%c Новый алгоритм ', 'background: green; color: white;');
+                        await volsSend({
+                            updated_at__from: new Date(lastSyncStart).toISOString(),
+                            is_active: '1',
+                            limit: '10000'
+                        });
+                        await groupBadgesSend({
+                            created_at__from: new Date(lastSyncStart).toISOString(),
+                            limit: '1000'
+                        });
+                        await syncTransactionsSend();
+                    }
+                    console.timeEnd('Время синхронизации');
                     success();
                 } catch (e) {
                     error(e);
                 }
             });
         },
-        [volsFetching, syncTransactionsFetching, volsSend, syncTransactionsSend, groupBadgesSend]
+        [
+            volsFetching,
+            syncTransactionsFetching,
+            groupBadgesFetching,
+            getTransFetching,
+            sendTransFetching,
+            deoptimizedSync,
+            sendTransSend,
+            volsSend,
+            groupBadgesSend,
+            getTransSend,
+            syncTransactionsSend
+        ]
     );
 
     return <ApiHook>useMemo(

--- a/packages/scanner/src/screens/main.tsx
+++ b/packages/scanner/src/screens/main.tsx
@@ -13,7 +13,8 @@ import { ScanSimulator } from '~/components/qr-scan-simulator';
 import css from '../app.module.css';
 
 export const MainScreen = React.memo(function MainScreen() {
-    const { appError, isDev, lastUpdate, setColor, setLastUpdated, setVolCount, volCount } = useContext(AppContext);
+    const { appError, debugMode, isDev, lastSyncStart, setColor, setLastSyncStart, setVolCount, volCount } =
+        useContext(AppContext);
     const [scanResult, setScanResult] = useState('');
 
     const closeFeedDialog = useCallback(() => {
@@ -27,14 +28,14 @@ export const MainScreen = React.memo(function MainScreen() {
 
     useEffect(() => {
         void db.volunteers.count().then((c) => setVolCount(c));
-        setLastUpdated(Number(localStorage.getItem('lastUpdated')));
+        setLastSyncStart(Number(localStorage.getItem('lastSyncStart')));
     }, []);
 
     return (
         <div className={cn(css.screen, css.main)}>
             <BtnSync />
             <div className={cn(css.screen, css.main)} style={{ display: scanResult ? 'none' : '' }}>
-                {isDev && <ScanSimulator withSelection setScanResult={setScanResult} />}
+                {(isDev || debugMode === '1') && <ScanSimulator withSelection setScanResult={setScanResult} />}
                 <QrScan onScan={setScanResult} />
                 <button className={css.anon} onClick={feedAnon}>
                     Кормить Анонима
@@ -43,7 +44,7 @@ export const MainScreen = React.memo(function MainScreen() {
             {scanResult && <PostScan closeFeed={closeFeedDialog} qrcode={scanResult} />}
 
             {appError && <ErrorMsg close={closeFeedDialog} msg={appError} />}
-            <LastUpdated count={volCount} ts={lastUpdate || 0} />
+            <LastUpdated count={volCount} ts={lastSyncStart || 0} />
             <MainScreenStats />
         </div>
     );


### PR DESCRIPTION
Новая синхронизация:

- Волонтеры и групповые бейджи запрашиваются с фильтром updated_at > last_sync
- Запрашиваем только активированных волонтеров
- Синхронизируем только новые транзакции:
```
feedapi/v1/feed-transaction/sync POST
req: {
  last_updated: время записи последней известной Кормителю транзакции в бд Джанго
  transactions: транзакции с флагом is_new
  kitchen_id: id кухни
}
res: {
  last_update: новое время записи последней транзакции в бд
  transactions: новые серверные транзакции
}
```
При удачной синхронизации в транзакциях Кормителя флаг is_new ставится false, в localstorage записывается новая дата синхронизации

Изменения:

1. Теперь kitchenId прописывается в транзакцию при ее создании
2. Удалены неиспользуемые индексы indexedDb
3. Исправлены ошибки в виджетах для создания мок транзакций
4. В localstorage добавлены флаги для тестирования:  
```
katya_testiruet: 1 // включает старую синхронизацию
debug: 1 // включает виджеты для создания мок транзакций
```