### PR TITLE
Фикс кормления группы анонимов

### DIFF
--- a/packages/scanner/src/components/post-scan/post-scan-cards/feed-anon-group-card/feed-anon-group-card.tsx
+++ b/packages/scanner/src/components/post-scan/post-scan-cards/feed-anon-group-card/feed-anon-group-card.tsx
@@ -10,6 +10,8 @@ import { TextArea } from '~/shared/ui/text-area';
 import { Input } from '~/shared/ui/input';
 import { removeNonDigits } from '~/shared/lib/utils';
 import { useValid } from '~/components/post-scan/post-scan-cards/feed-anon-group-card/utils/useValid';
+import { massFeedAnons } from '~/components/post-scan/post-scan.utils';
+import { useApp } from '~/model/app-provider';
 
 import css from './feed-anon-group-card.module.css';
 
@@ -21,8 +23,8 @@ export type Form = {
 
 export const FeedAnonGroupCard: FC<{
     close: () => void;
-    doFeed: (isVegan?: boolean, reason?: string) => void;
-}> = ({ close, doFeed }) => {
+}> = ({ close }) => {
+    const { kitchenId, mealTime } = useApp();
     const [form, setForm] = useState<Form>({
         meat: '',
         vegan: '',
@@ -35,17 +37,22 @@ export const FeedAnonGroupCard: FC<{
         setForm((prev) => ({ ...prev, ...change }));
     };
 
+    const feedAnons = async () => {
+        await massFeedAnons({
+            nonVegansCount: Number(form.meat),
+            vegansCount: Number(form.vegan),
+            kitchenId,
+            mealTime,
+            comment: form.comment || undefined
+        });
+        close();
+    };
+
     const handleSubmit = (e) => {
         e.preventDefault();
         const { valid } = validate();
         if (valid) {
-            for (let i = 0; i < +form.vegan; i++) {
-                doFeed(true, form.comment);
-            }
-            for (let i = 0; i < +form.meat; i++) {
-                doFeed(false, form.comment);
-            }
-            close();
+            void feedAnons();
         }
     };
     return (

--- a/packages/scanner/src/components/post-scan/post-scan-group-badge/post-scan-group-badge.tsx
+++ b/packages/scanner/src/components/post-scan/post-scan-group-badge/post-scan-group-badge.tsx
@@ -13,6 +13,7 @@ import {
     getGroupBadgeCurrentMealTransactions,
     getTodayStart,
     getVolTransactionsAsync,
+    massFeedAnons,
     validateVol
 } from '../post-scan.utils';
 
@@ -61,61 +62,6 @@ const useGroupBadgeData = ({
         }, [id]) ?? ([] as Array<TransactionJoined>);
 
     return { alreadyFedTransactions, vols };
-};
-
-// Кормим анонимов, если введено "другое число"
-const feedAnons = async ({
-    groupBadge,
-    kitchenId,
-    mealTime,
-    nonVegansCount,
-    vegansCount
-}: {
-    groupBadge: GroupBadge;
-    kitchenId: number;
-    vegansCount: number;
-    nonVegansCount: number;
-    mealTime?: MealTime | null;
-}): Promise<void> => {
-    if (!mealTime) {
-        return;
-    }
-
-    const createTransactionDraft = ({
-        isVegan
-    }: {
-        isVegan?: boolean;
-    } = {}): {
-        group_badge: number;
-        vol: null;
-        mealTime: MealTime;
-        isVegan?: boolean;
-        log: {
-            error: boolean;
-            reason: string;
-        };
-        kitchenId: number;
-    } => {
-        return {
-            vol: null,
-            mealTime,
-            isVegan,
-            log: { error: false, reason: 'Групповое питание' },
-            kitchenId,
-            group_badge: groupBadge.id
-        };
-    };
-
-    // Количество меньше нуля маловероятно, но, так как тип number предполагает такое поведение, стоит предусмотреть такой вариант
-    const vegans =
-        vegansCount <= 0 ? [] : Array.from(new Array(vegansCount), () => createTransactionDraft({ isVegan: true }));
-
-    // Количество меньше нуля маловероятно, но, так как тип number предполагает такое поведение, стоит предусмотреть такой вариант
-    const nonVegans = nonVegansCount <= 0 ? [] : Array.from(new Array(nonVegansCount), () => createTransactionDraft());
-
-    const promises = [...vegans, ...nonVegans].map((transactionDraft) => dbIncFeed(transactionDraft));
-
-    await Promise.all(promises);
 };
 
 // callback to feed vols
@@ -178,10 +124,12 @@ export const PostScanGroupBadge: FC<{
     };
 
     const doFeedAnons = (value: { vegansCount: number; nonVegansCount: number }): void => {
-        void feedAnons({ ...value, groupBadge, kitchenId, mealTime });
+        void massFeedAnons({ ...value, groupBadge, kitchenId, mealTime });
     };
 
-    const leftToFeedInBadge = validationGroups.greens.length - (alreadyFedTransactions?.length ?? 0);
+    const leftToFeedInBadge =
+        // Транзакции кормления анонимов по групповому бейджу могут содержать значение amount, отличное от 1
+        validationGroups.greens.length - (alreadyFedTransactions?.reduce((count, next) => count + next.amount, 0) ?? 0);
 
     useEffect(() => {
         // loading

--- a/packages/scanner/src/components/post-scan/post-scan.utils.ts
+++ b/packages/scanner/src/components/post-scan/post-scan.utils.ts
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import { useCallback } from 'react';
 
 import { getTodayTrans, db, dbIncFeed, FeedType, isActivatedStatus, MealTime } from '~/db';
-import type { Transaction, TransactionJoined, Volunteer } from '~/db';
+import type { Transaction, TransactionJoined, Volunteer, GroupBadge } from '~/db';
 import { getMealTimeText } from '~/shared/lib/utils';
 
 const isVolExpired = (vol: Volunteer): boolean => {
@@ -114,6 +114,68 @@ export const validateVol = ({
     return { msg, isRed, isActivated };
 };
 
+// Кормим большое количество анонимов, если введено "другое число"
+export const massFeedAnons = async ({
+    comment = '',
+    groupBadge,
+    kitchenId,
+    mealTime,
+    nonVegansCount,
+    vegansCount
+}: {
+    groupBadge?: GroupBadge;
+    kitchenId: number;
+    vegansCount: number;
+    nonVegansCount: number;
+    mealTime?: MealTime | null;
+    comment?: string;
+}): Promise<void> => {
+    if (!mealTime) {
+        return;
+    }
+
+    const createTransactionDraft = ({
+        amount = 1,
+        isVegan
+    }: {
+        isVegan?: boolean;
+        amount?: number;
+    } = {}): {
+        group_badge?: number;
+        vol: null;
+        mealTime: MealTime;
+        isVegan?: boolean;
+        log: {
+            error: boolean;
+            reason: string;
+        };
+        amount: number;
+        kitchenId: number;
+    } => {
+        return {
+            amount,
+            vol: null,
+            mealTime,
+            isVegan: Boolean(isVegan),
+            log: { error: false, reason: comment + (!!groupBadge ? ' Групповое питание' : '') },
+            kitchenId,
+            group_badge: groupBadge?.id
+        };
+    };
+
+    // Количество меньше нуля маловероятно, но, так как тип number предполагает такое поведение, стоит предусмотреть такой вариант
+    const vegans = vegansCount <= 0 ? [] : [createTransactionDraft({ isVegan: true, amount: vegansCount })];
+
+    // Количество меньше нуля маловероятно, но, так как тип number предполагает такое поведение, стоит предусмотреть такой вариант
+    const nonVegans = nonVegansCount <= 0 ? [] : [createTransactionDraft({ isVegan: false, amount: nonVegansCount })];
+
+    console.log('someeee', [...vegans, ...nonVegans]);
+
+    const promises = [...vegans, ...nonVegans].map((transactionDraft) => dbIncFeed(transactionDraft));
+
+    await Promise.all(promises);
+};
+
 export const getTodayStart = (): number => dayjs().subtract(7, 'h').startOf('day').add(7, 'h').unix();
 
 let isFeedInProgress = false;
@@ -141,19 +203,17 @@ export const useFeedVol = (
         [closeFeed, kitchenId, mealTime, vol]
     );
 
-    const doFeed = useCallback(
-        (isVegan?: boolean, reason?: string) => {
-            let log;
+    const doFeed = (isVegan?: boolean, reason?: string) => {
+        let log;
 
-            if (reason) {
-                log = { error: false, reason };
-            }
+        if (reason) {
+            log = { error: false, reason };
+        }
 
-            void feed(isVegan, log);
-        },
-        [feed]
-    );
-    const doNotFeed = useCallback((reason: string) => void feed(undefined, { error: true, reason }), [feed]);
+        void feed(isVegan, log);
+    };
+
+    const doNotFeed = (reason: string) => void feed(undefined, { error: true, reason });
 
     return {
         doFeed,

--- a/packages/scanner/src/components/post-scan/post-scan.utils.ts
+++ b/packages/scanner/src/components/post-scan/post-scan.utils.ts
@@ -169,8 +169,6 @@ export const massFeedAnons = async ({
     // Количество меньше нуля маловероятно, но, так как тип number предполагает такое поведение, стоит предусмотреть такой вариант
     const nonVegans = nonVegansCount <= 0 ? [] : [createTransactionDraft({ isVegan: false, amount: nonVegansCount })];
 
-    console.log('someeee', [...vegans, ...nonVegans]);
-
     const promises = [...vegans, ...nonVegans].map((transactionDraft) => dbIncFeed(transactionDraft));
 
     await Promise.all(promises);

--- a/packages/scanner/src/db.ts
+++ b/packages/scanner/src/db.ts
@@ -103,6 +103,7 @@ export class MySubClassedDexie extends Dexie {
 export const db = new MySubClassedDexie();
 
 export const addTransaction = async ({
+    amount,
     group_badge,
     isVegan,
     kitchenId,
@@ -119,13 +120,14 @@ export const addTransaction = async ({
         reason: string;
     };
     group_badge?: number | null;
+    amount?: number;
 }): Promise<any> => {
     const ts = dayjs().unix();
-    let amount = 1;
+    let amountInner = amount ?? 1;
     let reason: string | null = null;
     if (log) {
         if (log.error) {
-            amount = 0;
+            amountInner = 0;
         }
 
         reason = log.reason;
@@ -136,7 +138,7 @@ export const addTransaction = async ({
         is_vegan: vol ? vol.is_vegan : isVegan,
         ts,
         kitchen: kitchenId,
-        amount,
+        amount: amountInner,
         ulid: ulid(ts),
         mealTime: MealTime[mealTime],
         is_new: true,
@@ -146,6 +148,7 @@ export const addTransaction = async ({
 };
 
 export const dbIncFeed = async ({
+    amount,
     group_badge,
     isVegan,
     kitchenId,
@@ -153,6 +156,7 @@ export const dbIncFeed = async ({
     mealTime,
     vol
 }: {
+    amount?: number;
     group_badge?: number | null;
     vol?: Volunteer | null;
     mealTime: MealTime;
@@ -163,7 +167,7 @@ export const dbIncFeed = async ({
     };
     kitchenId: number;
 }): Promise<any> => {
-    return await addTransaction({ group_badge, vol, mealTime, isVegan, log, kitchenId });
+    return await addTransaction({ amount, group_badge, vol, mealTime, isVegan, log, kitchenId });
 };
 
 export function joinTxs(txsCollection: Collection<TransactionJoined>): Promise<Array<TransactionJoined>> {


### PR DESCRIPTION
Теперь группа покормленных анонимов учитывается правильно.
Дополнительно, теперь транзакции покормленных анонимов создаются иначе: 1 транзакция на 1 кормление, вне зависимости от количества анонимов (разделение на типы веганов и мясоедов - осталось)