### PR TITLE
Fix: note not visible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "husky": "^8.0.3",
                 "leasot": "^13.2.0",
                 "npm-run-all": "^4.1.5",
+                "recharts": "^2.15.1",
                 "rimraf": "^4.1.2"
             },
             "devDependencies": {
@@ -25909,15 +25910,15 @@
             }
         },
         "node_modules/recharts": {
-            "version": "2.15.0",
-            "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.0.tgz",
-            "integrity": "sha512-cIvMxDfpAmqAmVgc4yb7pgm/O1tmmkl/CjrvXuW+62/+7jj/iF9Ykm+hb/UJt42TREHMyd3gb+pkgoa2MxgDIw==",
+            "version": "2.15.1",
+            "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.1.tgz",
+            "integrity": "sha512-v8PUTUlyiDe56qUj82w/EDVuzEFXwEHp9/xOowGAZwfLjB9uAy3GllQVIYMWF6nU+qibx85WF75zD7AjqoT54Q==",
             "dependencies": {
                 "clsx": "^2.0.0",
                 "eventemitter3": "^4.0.1",
                 "lodash": "^4.17.21",
                 "react-is": "^18.3.1",
-                "react-smooth": "^4.0.0",
+                "react-smooth": "^4.0.4",
                 "recharts-scale": "^0.4.4",
                 "tiny-invariant": "^1.3.1",
                 "victory-vendor": "^36.6.8"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "husky": "^8.0.3",
         "leasot": "^13.2.0",
         "npm-run-all": "^4.1.5",
+        "recharts": "^2.15.1",
         "rimraf": "^4.1.2"
     },
     "peerDependencies": {

--- a/packages/admin/src/components/entities/group-badges/group-badge-list.module.css
+++ b/packages/admin/src/components/entities/group-badges/group-badge-list.module.css
@@ -3,6 +3,7 @@
     flex-direction: column;
     gap: 12px;
     width: 100%;
+    padding-bottom: 56px;
 }
 
 .card {

--- a/packages/admin/src/components/entities/vols/list.module.css
+++ b/packages/admin/src/components/entities/vols/list.module.css
@@ -62,6 +62,7 @@
     flex-direction: column;
     gap: 8px;
     width: 100%;
+    padding-bottom: 56px;
 }
 
 .volCard {


### PR DESCRIPTION
К задаче https://github.com/Insomnia-IT/feed/issues/377
Поправил п3. Также обратил внимание, что в соседней вкладке "группы" карточка группового бейджа тоже перекрывалась. В итоге поправил во вкладке "Волонтеры" и во вкладке "Группы"
<img width="457" alt="Снимок экрана 2025-03-09 в 17 47 21" src="https://github.com/user-attachments/assets/8f022b5d-6939-4071-a685-0e9442e55101" />
