### PR TITLE
fix: Critical Исправлен импорт из библиотеки

### DIFF
--- a/packages/admin/src/components/wash/list/washes-history.tsx
+++ b/packages/admin/src/components/wash/list/washes-history.tsx
@@ -4,7 +4,7 @@ import { WashEntity } from 'interfaces';
 import { useNavigate } from 'react-router-dom';
 import { transformWashesForShow, WashToShow } from './utils';
 import { SaveWashesAsExcelButton } from './save-washes-as-excel-button';
-import { ExperimentOutlined } from '@ant-design/icons/lib/icons';
+import { ExperimentOutlined } from '@ant-design/icons';
 import type { Dayjs } from 'dayjs';
 
 export const WashesHistory = () => {


### PR DESCRIPTION
такой импорт тянул все иконки в билд, из-за этого размер билда значительно увеличился, надо завести задачу под это и попросить тестирование посмотреть иконки в стирателе, что они все там остались 