### PR TITLE
UX таблицы волонтёров и фильтров на этой странице в рамках задачи #953

### DIFF
--- a/.github/workflows/rum_deploy_pr.yml
+++ b/.github/workflows/rum_deploy_pr.yml
@@ -23,6 +23,9 @@ jobs:
     env:
       PROJECT_NAME: feed-pr-${{ github.event.number }}
       DB_DIR: /tmp/feed_db_pr_${{ github.event.number }}
+      # Старый шаблон PORT=9${PR} давал склейку строк (PR #1004 → 91004 > 65535).
+      # 9000+PR совпадает с прежним числом для 3-значных PR (508 → 9508) и остаётся ≤65535.
+      PR_PREVIEW_PORT: ${{ 9000 + github.event.number }}
       PHOTO_STORAGE_PATH: /var/feed_db/photos/
     #   PHOTO_AUTH_TOKEN: ${{ secrets.PHOTO_AUTH_TOKEN }}
     steps:
@@ -47,7 +50,7 @@ jobs:
     - name: run admin
       if: ${{ github.event.action != 'closed' && github.event.pull_request.draft == false }}
       run: |
-        ALLOWED_HOSTS=9${{ github.event.number }}.feedapp-dev.insomniafest.ru,localhost DB_DIR=${DB_DIR} PHOTO_STORAGE_PATH=${PHOTO_STORAGE_PATH} PHOTO_AUTH_TOKEN=${PHOTO_AUTH_TOKEN} SKIP_BACK_SYNC=False PORT=9${{ github.event.number }} docker compose -f docker-compose.pr.yml -p $PROJECT_NAME up -d --remove-orphans --force-recreate
+        ALLOWED_HOSTS=9${{ github.event.number }}.feedapp-dev.insomniafest.ru,localhost DB_DIR=${DB_DIR} PHOTO_STORAGE_PATH=${PHOTO_STORAGE_PATH} PHOTO_AUTH_TOKEN=${PHOTO_AUTH_TOKEN} SKIP_BACK_SYNC=False PORT=${PR_PREVIEW_PORT} docker compose -f docker-compose.pr.yml -p $PROJECT_NAME up -d --remove-orphans --force-recreate
     - name: Create app link
       if: ${{ github.event.action != 'closed' && github.event.pull_request.draft == false }}
       id: create-link

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@
 **/dist
 
 # misc
+.pyenv/
+
 .DS_Store
 .env.local
 .env.development.local

--- a/docker-compose.pr.yml
+++ b/docker-compose.pr.yml
@@ -1,4 +1,3 @@
-version: '3.5'
 name: feed
 
 services:

--- a/packages/admin/src/components/entities/vols/list.module.css
+++ b/packages/admin/src/components/entities/vols/list.module.css
@@ -224,3 +224,44 @@
     z-index: 1;
     border-radius: 8px;
 }
+
+/*
+ * Подсветка полей с ненулевым значением (поиск и фильтры волонтёров).
+ * Глобальный ConfigProvider в app.tsx задаёт только token.borderRadius — отдельного preset для «filled» у Input нет.
+ */
+
+.volSearchBlock {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    width: 100%;
+}
+
+/* Обёртка строки поиска на всю ширину блока контента */
+.volSearchWrap {
+    width: 100%;
+}
+
+/*
+ * Растягивание контрола внутри ant Row (flex): без этого обёртка сжимается до ширины иконки,
+ * Select теряет плейсхолдер и выглядит «сплющенным».
+ */
+.volFilterControlStretch {
+    flex: 1 1 auto;
+    width: 100%;
+    min-width: 110px;
+    max-width: 100%;
+    box-sizing: border-box;
+}
+
+.volActiveControlRing {
+    /*
+     * Радиус совпадает с token.borderRadius и скруглением Input/Select Ant Design —
+     * иначе при 8px кольцо расходится с контролом и на углах линия выглядит «рваной».
+     */
+    border-radius: 6px;
+    transition: box-shadow 0.2s ease;
+
+    /* Без размытой тени; 2px; приглушённый «серо-голубой», без крика цвета */
+    box-shadow: 0 0 0 2px rgb(152 180 218 / 48%);
+}

--- a/packages/admin/src/components/entities/vols/list.tsx
+++ b/packages/admin/src/components/entities/vols/list.tsx
@@ -94,7 +94,7 @@ const DesktopVolunteersContent = ({
     canListCustomFields: boolean;
     isFiltersLoading: boolean;
     searchText: string;
-    activeFilters: unknown[];
+    activeFilters: FilterItem[];
     openVolunteer: (id: number) => Promise<boolean>;
 }) => {
     const { result: volunteersResult, query: volunteersQuery } = useList<VolEntity>({

--- a/packages/admin/src/components/entities/vols/list.tsx
+++ b/packages/admin/src/components/entities/vols/list.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useList, CanAccess, useGetIdentity } from '@refinedev/core';
+import { useList, CanAccess, useGetIdentity, useTranslate } from '@refinedev/core';
 import { List } from '@refinedev/antd';
-import { Input, Row, Col, Segmented } from 'antd';
+import { App, Button, Input, Row, Col, Segmented, Typography } from 'antd';
+import { PlusSquareOutlined } from '@ant-design/icons';
 import type { TablePaginationConfig } from 'antd/es/table';
 import { useNavigate } from 'react-router';
 
@@ -14,6 +15,8 @@ import type { UserData } from 'auth';
 import type { CustomFieldEntity, VolEntity } from 'interfaces';
 
 import { Filters } from './vol-list/filters/filters';
+import { isEffectiveFilterValue } from './vol-list/filters/is-effective-filter-value';
+import type { FilterItem } from 'components/entities/vols/vol-list/filters/filter-types';
 import { useFilters } from 'components/entities/vols/vol-list/filters/use-filters';
 import { SaveAsXlsxButton } from './vol-list/save-as-xlsx-button';
 import { ChooseColumnsButton } from './vol-list/choose-columns-button';
@@ -24,12 +27,45 @@ import { useMassEdit } from './vol-list/mass-edit/use-mass-edit';
 import { MassEdit } from './vol-list/mass-edit/mass-edit';
 import { PersonsTable } from './vol-list/persons-table';
 
+import styles from './list.module.css';
+
 const LS_PAGE_INDEX = 'volPageIndex';
 const LS_PAGE_SIZE = 'volPageSize';
 
 const getPositiveNumber = (value: string | null, fallback: number) => {
     const parsed = Number(value);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const VolunteersListCreateButton = ({ activeFilters }: { activeFilters: FilterItem[] }) => {
+    const navigate = useNavigate();
+    const translate = useTranslate();
+    const canCreateVolunteer = useCanAccess({ action: 'create', resource: 'volunteers' });
+    const { modal } = App.useApp();
+
+    if (!canCreateVolunteer) {
+        return null;
+    }
+
+    return (
+        <Button
+            type="primary"
+            icon={<PlusSquareOutlined />}
+            onClick={() => {
+                if (activeFilters.some(({ value }) => isEffectiveFilterValue(value))) {
+                    modal.warning({
+                        title: 'Применены фильтры',
+                        content:
+                            'Список сейчас может быть неполным: при активных фильтрах волонтёр может не отображаться, хотя он уже есть в базе. Сбросьте фильтры и ещё раз поищите, прежде чем создавать новую запись.'
+                    });
+                    return;
+                }
+                void navigate('/volunteers/create');
+            }}
+        >
+            {translate('buttons.create', 'Создать')}
+        </Button>
+    );
 };
 
 const DesktopVolunteersContent = ({
@@ -110,9 +146,9 @@ const DesktopVolunteersContent = ({
         [volunteers?.total, page, pageSize, setPageWithStorage, setPageSizeWithStorage]
     );
 
-    const noActiveFilters = activeFilters.length === 0;
+    const noEffectiveFilters = !activeFilters.some(({ value }) => isEffectiveFilterValue(value));
     const volunteersData = volunteers?.data ?? [];
-    const showPersons = !!searchText && noActiveFilters && volunteersData.length === 0;
+    const showPersons = !!searchText && noEffectiveFilters && volunteersData.length === 0;
 
     return (
         <>
@@ -320,22 +356,34 @@ export const VolList = () => {
         return Promise.resolve(true);
     };
 
-    const noActiveFilters = activeFilters.length === 0;
-
     return (
-        <List canCreate={noActiveFilters}>
+        <List canCreate headerButtons={() => <VolunteersListCreateButton activeFilters={activeFilters} />}>
             <CanAccess fallback="У вас нет доступа к этой странице">
                 <ActiveColumnsContextProvider customFields={customFields}>
-                    <Input
-                        placeholder="Поиск по волонтерам, датам, службам"
-                        value={searchInputValue}
-                        onChange={(e) => {
-                            const nextValue = e.target.value;
-                            setSearchInputValue(nextValue);
-                            debouncedSetSearchText(nextValue);
-                        }}
-                        allowClear
-                    />
+                    <div className={styles.volSearchBlock}>
+                        <Typography.Text type="secondary">Поиск по волонтёрам</Typography.Text>
+                        <div
+                            className={
+                                [
+                                    styles.volSearchWrap,
+                                    searchInputValue.trim().length > 0 && styles.volActiveControlRing
+                                ]
+                                    .filter(Boolean)
+                                    .join(' ') || undefined
+                            }
+                        >
+                            <Input
+                                placeholder="Поиск по волонтерам, датам, службам"
+                                value={searchInputValue}
+                                onChange={(e) => {
+                                    const nextValue = e.target.value;
+                                    setSearchInputValue(nextValue);
+                                    debouncedSetSearchText(nextValue);
+                                }}
+                                allowClear
+                            />
+                        </div>
+                    </div>
                     <Filters
                         activeFilters={activeFilters}
                         setActiveFilters={setActiveFilters}
@@ -343,8 +391,6 @@ export const VolList = () => {
                         setVisibleFilters={setVisibleFilters}
                         filterFields={filterFields}
                         isMobile={isMobile}
-                        searchText={searchText}
-                        setSearchText={setSearchText}
                         mobileSummary={!isDesktop ? <span>Найдено: {mobileTotal}</span> : undefined}
                     />
                     {isMyBrigadeAvailable && (

--- a/packages/admin/src/components/entities/vols/vol-list/filters/filter-chooser.tsx
+++ b/packages/admin/src/components/entities/vols/vol-list/filters/filter-chooser.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
-import { DownOutlined } from '@ant-design/icons';
-import { Select } from 'antd';
+import { useRef, useState } from 'react';
+import { FilterOutlined } from '@ant-design/icons';
+import { Button, Popover, Select } from 'antd';
 
 import type { FilterField } from './filter-types';
 import styles from '../../list.module.css';
@@ -28,44 +28,51 @@ export const FilterChooser = ({
     toggleVisibleFilter: (name: string) => void;
     visibleFilters: Array<string>;
 }) => {
-    const [dropdownOpen, setDropdownOpen] = useState(false);
+    const selectRef = useRef<React.ComponentRef<typeof Select>>(null);
+    const [selectOpen, setSelectOpen] = useState(false);
     const options = filterFields.map(mapFilterFieldsToOptions);
 
-    const onChange = (_id: string, item: IFilterOption): void => {
-        toggleVisibleFilter(item.value);
+    const onChoiceChange = (_value: string, option: IFilterOption): void => {
+        toggleVisibleFilter(option.value);
     };
 
     return (
-        <Select
-            className={styles.filterChooserSelect}
-            style={{ minWidth: '200px', maxWidth: '350px' }}
-            open={dropdownOpen}
-            onDropdownVisibleChange={setDropdownOpen}
-            mode={'multiple'}
-            value={visibleFilters}
-            autoFocus={true}
-            options={options}
-            optionFilterProp={'label'}
-            onSelect={onChange}
-            onDeselect={onChange}
-            onClear={removeAllFilters}
-            showSearch
-            allowClear={false}
-            suffixIcon={
-                <span
-                    role="button"
-                    tabIndex={-1}
-                    aria-expanded={dropdownOpen}
-                    style={{ display: 'inline-flex', alignItems: 'center', cursor: 'pointer' }}
-                    onMouseDown={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        setDropdownOpen((prev) => !prev);
-                    }}
-                >
-                    <DownOutlined />
-                </span>
+        <Popover
+            placement="bottomLeft"
+            trigger="click"
+            /* Убирает «зависшие» порталы/скроллбар списка Select после закрытия */
+            destroyOnHidden
+            afterOpenChange={(open) => {
+                if (open) {
+                    setSelectOpen(true);
+                    selectRef.current?.focus();
+                } else {
+                    setSelectOpen(false);
+                }
+            }}
+            content={
+                <Select
+                    ref={selectRef}
+                    open={selectOpen}
+                    onOpenChange={setSelectOpen}
+                    getPopupContainer={(trigger) =>
+                        trigger.closest('.ant-popover-inner-content') ?? trigger.parentElement ?? document.body
+                    }
+                    className={styles.filterChooserSelect}
+                    style={{ minWidth: '200px', maxWidth: '350px' }}
+                    mode="multiple"
+                    value={visibleFilters}
+                    options={options}
+                    optionFilterProp="label"
+                    onSelect={onChoiceChange}
+                    onDeselect={onChoiceChange}
+                    onClear={removeAllFilters}
+                    showSearch
+                    allowClear={false}
+                />
             }
-        />
+        >
+            <Button icon={<FilterOutlined />}>Фильтры</Button>
+        </Popover>
     );
 };

--- a/packages/admin/src/components/entities/vols/vol-list/filters/filter-item-control.tsx
+++ b/packages/admin/src/components/entities/vols/vol-list/filters/filter-item-control.tsx
@@ -6,6 +6,7 @@ import dayjs from 'dayjs';
 import { FilterFieldType } from './filter-types';
 import type { FilterField, FilterItem, FilterListItem } from './filter-types';
 import { getFilterListItems } from './get-filter-list-items';
+import { isEffectiveFilterValue } from './is-effective-filter-value';
 import styles from '../../list.module.css';
 
 const fieldStyle = {
@@ -24,6 +25,9 @@ const INPUT_PLACEHOLDER = 'Введи текст';
 const SELECT_PLACEHOLDER = 'Выбери из списка';
 const FROM_LABEL = 'С';
 const TO_LABEL = 'По';
+
+const stretchAndRingClass = (active: boolean): string | undefined =>
+    [styles.volFilterControlStretch, active && styles.volActiveControlRing].filter(Boolean).join(' ') || undefined;
 
 export const FilterItemControl: FC<{
     field: FilterField;
@@ -89,7 +93,7 @@ const DateField: FC<{
             <Row style={{ justifyContent: 'space-between' }}>
                 <Typography.Text type={'secondary'}>{field.title}</Typography.Text>
             </Row>
-            <Row>
+            <Row className={stretchAndRingClass(isEffectiveFilterValue(filterItem?.value))} style={{ width: '100%' }}>
                 {showPeriod ? (
                     isMobile ? (
                         <Col flex="auto">
@@ -216,15 +220,17 @@ const FilterInput: FC<{
             <Row>
                 <Typography.Text type={'secondary'}>{field.title}</Typography.Text>
             </Row>
-            <Row>
-                <Input
-                    style={fieldStyle}
-                    value={filterItem?.value as string | undefined}
-                    onChange={(e) => onFilterTextValueChange(field.name, e.target.value)}
-                    placeholder={INPUT_PLACEHOLDER}
-                    onClear={onClear}
-                    allowClear
-                />
+            <Row style={{ width: '100%' }}>
+                <div className={stretchAndRingClass(isEffectiveFilterValue(filterItem?.value))}>
+                    <Input
+                        style={{ ...fieldStyle, width: '100%' }}
+                        value={filterItem?.value as string | undefined}
+                        onChange={(e) => onFilterTextValueChange(field.name, e.target.value)}
+                        placeholder={INPUT_PLACEHOLDER}
+                        onClear={onClear}
+                        allowClear
+                    />
+                </div>
             </Row>
         </Col>
     );
@@ -263,39 +269,41 @@ const FilterSelect: FC<{
             <Row>
                 <Typography.Text type={'secondary'}>{field.title}</Typography.Text>
             </Row>
-            <Row>
-                <Select
-                    className={styles.filterValueSelect}
-                    style={{ width: '100%' }}
-                    open={dropdownOpen}
-                    onDropdownVisibleChange={setDropdownOpen}
-                    maxTagCount={1}
-                    value={selectValue as string[] | string | number | boolean | undefined}
-                    onSelect={onSelect}
-                    onDeselect={onDeselect}
-                    onClear={onClear}
-                    options={values}
-                    placeholder={SELECT_PLACEHOLDER}
-                    optionFilterProp={'label'}
-                    mode={isMultiple ? 'multiple' : undefined}
-                    showSearch
-                    allowClear={false}
-                    suffixIcon={
-                        <span
-                            role="button"
-                            tabIndex={-1}
-                            aria-expanded={dropdownOpen}
-                            style={{ display: 'inline-flex', alignItems: 'center', cursor: 'pointer' }}
-                            onMouseDown={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                setDropdownOpen((prev) => !prev);
-                            }}
-                        >
-                            <DownOutlined />
-                        </span>
-                    }
-                />
+            <Row style={{ width: '100%' }}>
+                <div className={stretchAndRingClass(isEffectiveFilterValue(filterItem?.value))}>
+                    <Select
+                        className={styles.filterValueSelect}
+                        style={{ width: '100%' }}
+                        open={dropdownOpen}
+                        onDropdownVisibleChange={setDropdownOpen}
+                        maxTagCount={1}
+                        value={selectValue as string[] | string | number | boolean | undefined}
+                        onSelect={onSelect}
+                        onDeselect={onDeselect}
+                        onClear={onClear}
+                        options={values}
+                        placeholder={SELECT_PLACEHOLDER}
+                        optionFilterProp={'label'}
+                        mode={isMultiple ? 'multiple' : undefined}
+                        showSearch
+                        allowClear={false}
+                        suffixIcon={
+                            <span
+                                role="button"
+                                tabIndex={-1}
+                                aria-expanded={dropdownOpen}
+                                style={{ display: 'inline-flex', alignItems: 'center', cursor: 'pointer' }}
+                                onMouseDown={(e) => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    setDropdownOpen((prev) => !prev);
+                                }}
+                            >
+                                <DownOutlined />
+                            </span>
+                        }
+                    />
+                </div>
             </Row>
         </Col>
     );

--- a/packages/admin/src/components/entities/vols/vol-list/filters/filters.tsx
+++ b/packages/admin/src/components/entities/vols/vol-list/filters/filters.tsx
@@ -10,8 +10,6 @@ import styles from '../../list.module.css';
 
 import { isEffectiveFilterValue } from './is-effective-filter-value';
 
-export { isEffectiveFilterValue } from './is-effective-filter-value';
-
 interface IProps {
     filterFields: FilterField[];
     isMobile?: boolean;

--- a/packages/admin/src/components/entities/vols/vol-list/filters/filters.tsx
+++ b/packages/admin/src/components/entities/vols/vol-list/filters/filters.tsx
@@ -1,6 +1,6 @@
 import { useMemo, type ReactNode } from 'react';
-import { DeleteOutlined, FilterOutlined } from '@ant-design/icons';
-import { Button, Col, Popover, Row } from 'antd';
+import { DeleteOutlined } from '@ant-design/icons';
+import { Button, Col, Row } from 'antd';
 
 import { FilterChooser } from './filter-chooser';
 import { FilterItemControl } from './filter-item-control';
@@ -8,11 +8,13 @@ import type { FilterField, FilterItem, FilterListItem } from './filter-types';
 
 import styles from '../../list.module.css';
 
+import { isEffectiveFilterValue } from './is-effective-filter-value';
+
+export { isEffectiveFilterValue } from './is-effective-filter-value';
+
 interface IProps {
     filterFields: FilterField[];
     isMobile?: boolean;
-    searchText?: string;
-    setSearchText?: (value: string) => void;
     mobileSummary?: ReactNode;
     visibleFilters: string[];
     setVisibleFilters: (filters: string[]) => void;
@@ -25,8 +27,6 @@ export const Filters = ({
     filterFields,
     isMobile,
     mobileSummary,
-    searchText,
-    setSearchText,
     setActiveFilters,
     visibleFilters,
     setVisibleFilters
@@ -99,6 +99,11 @@ export const Filters = ({
                 newValues = [...filterItem.value, filterListItem.value];
             }
 
+            if (newValues.length === 0) {
+                setActiveFilters(activeFilters.filter((f) => f.name !== fieldName));
+                return;
+            }
+
             const newFilters = activeFilters
                 .filter((f) => f.name !== fieldName)
                 .concat([
@@ -142,12 +147,13 @@ export const Filters = ({
         [visibleFiltersFields, activeFilterByName]
     );
 
+    const showClearFiltersButton = useMemo(
+        () => activeFilters.some(({ value }) => isEffectiveFilterValue(value)),
+        [activeFilters]
+    );
+
     const resetFilters = () => {
         setActiveFilters([]);
-
-        if (setSearchText) {
-            setSearchText('');
-        }
     };
 
     return (
@@ -156,21 +162,12 @@ export const Filters = ({
                 <div className={isMobile ? styles.mobileFiltersHeader : undefined}>
                     <Col style={{ width: '105px' }}>
                         <Row>
-                            <Popover
-                                key="add-filter"
-                                placement="bottomLeft"
-                                content={
-                                    <FilterChooser
-                                        removeAllFilters={removeAllFilters}
-                                        filterFields={filterFields}
-                                        toggleVisibleFilter={toggleVisibleFilter}
-                                        visibleFilters={visibleFilters}
-                                    />
-                                }
-                                trigger="click"
-                            >
-                                <Button icon={<FilterOutlined />}>Фильтры</Button>
-                            </Popover>
+                            <FilterChooser
+                                removeAllFilters={removeAllFilters}
+                                filterFields={filterFields}
+                                toggleVisibleFilter={toggleVisibleFilter}
+                                visibleFilters={visibleFilters}
+                            />
                         </Row>
                     </Col>
                     {isMobile && mobileSummary && <div className={styles.mobileFiltersSummary}>{mobileSummary}</div>}
@@ -186,7 +183,7 @@ export const Filters = ({
                         onFilterValueChange={onFilterValueChange}
                     />
                 ))}
-                {(activeFilters.length || searchText) && (
+                {showClearFiltersButton && (
                     <Button icon={<DeleteOutlined />} onClick={resetFilters}>
                         Очистить фильтры
                     </Button>

--- a/packages/admin/src/components/entities/vols/vol-list/filters/is-effective-filter-value.ts
+++ b/packages/admin/src/components/entities/vols/vol-list/filters/is-effective-filter-value.ts
@@ -1,0 +1,13 @@
+/** Whether a filter item contributes to the API query (non-empty value). */
+export const isEffectiveFilterValue = (value: unknown): boolean => {
+    if (value == null) {
+        return false;
+    }
+    if (Array.isArray(value)) {
+        return value.length > 0;
+    }
+    if (typeof value === 'string') {
+        return value.trim().length > 0;
+    }
+    return true;
+};


### PR DESCRIPTION
**Кнопка «Создать»**
Кнопка всегда доступна (при наличии права на создание).
Если включены реально действующие фильтры (не пустые / не «по умолчанию»), при нажатии показывается предупреждение (модальное окно): список может быть неполным, переход на создание — осознанный выбор пользователя.

Если нет эффективных фильтров, сразу выполняется переход на /volunteers/create.
Вместо CreateButton из Refine использованы обычные Ant Design Button, App.useApp().modal и navigate, чтобы корректно обрабатывать клики и проверку прав (useCanAccess).


**«Очистить фильтры»**
Кнопка отображается только когда есть что очищать — то есть при effective значениях фильтров.
Поле поиска не считается фильтром в этом смысле и не сбрасывается этой кнопкой.
Для lookup-фильтров: при снятии всех значений фильтр удаляется из состояния, а не остаётся с пустым массивом.

**Общая логика «эффективности» фильтра**
Вынесена функция isEffectiveFilterValue в отдельный модуль (is-effective-filter-value.ts), чтобы переиспользовать её без циклических импортов между компонентами фильтров.

**Визуал и разметка**
Добавлены стили в list.module.css и обёртки в list.tsx / filter-item-control.tsx: подсветка блоков, где задано значение фильтра (лёгкое «кольцо» в тон темы Ant Design, согласованный радиус скругления).
Над полем поиска добавлен подпись Поиск по волонтёрам (вторичный текст по типографике темы).

**FilterChooser (фильтры в поповере)**
Переработаны filter-chooser.tsx и связанные места: поповер и Select работают предсказуемо (управляемое открытие, фокус после открытия, destroyOnHidden у поповера, getPopupContainer у селекта на контент поповера), чтобы не оставались артефакты выпадающих списков в document.body.