### PR TITLE
fix(admin): переход на вкладку с ошибкой валидации

### DIFF
--- a/packages/admin/src/components/entities/group-badges/edit/group-badge-edit.tsx
+++ b/packages/admin/src/components/entities/group-badges/edit/group-badge-edit.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Edit, useForm } from '@refinedev/antd';
-import { Form } from 'antd';
+import { Form, type FormProps } from 'antd';
 import { type HttpError } from '@refinedev/core';
 
 import type { GroupBadgeEntity } from 'interfaces';
@@ -8,11 +8,42 @@ import { useScreen } from 'shared/providers';
 import { GroupBadgeTabs } from './group-badge-tabs/group-badge-tabs';
 import styles from './group-badge-edit.module.css';
 
+/** Поля вкладки «Основное» (CreateEdit) — см. при map новых вкладок с полями формы */
+const GROUP_BADGE_MAIN_TAB_FIELDS = ['name', 'direction', 'role', 'qr', 'comment'] as const;
+
+const validationFieldTabKey = (fieldName: (string | number)[]): string => {
+    const segment = fieldName[0];
+
+    if (typeof segment === 'string' && (GROUP_BADGE_MAIN_TAB_FIELDS as readonly string[]).includes(segment)) {
+        return '1';
+    }
+
+    return '1';
+};
+
 export const GroupBadgeEdit = () => {
-    const { id, formProps, saveButtonProps } = useForm<GroupBadgeEntity, HttpError>();
+    const { id, formProps, saveButtonProps, form } = useForm<GroupBadgeEntity, HttpError>();
+    const { onFinishFailed: upstreamOnFinishFailed, ...restFormProps } = formProps;
     const { isDesktop } = useScreen();
     const [activeKey, setActiveKey] = useState('1');
     const shouldHideFooterActions = !isDesktop && activeKey !== '1';
+
+    const handleFinishFailed: NonNullable<FormProps['onFinishFailed']> = (errorInfo) => {
+        const sorted = [...(errorInfo.errorFields ?? [])].sort((a, b) =>
+            String(a.name?.[0]).localeCompare(String(b.name?.[0]))
+        );
+        const first = sorted.find((field) => field.name?.length);
+        const namePath = first?.name;
+
+        if (namePath?.length) {
+            setActiveKey(validationFieldTabKey(namePath));
+            window.setTimeout(() => {
+                void form.scrollToField(namePath, { behavior: 'smooth', block: 'nearest', focus: true });
+            }, 100);
+        }
+
+        upstreamOnFinishFailed?.(errorInfo);
+    };
 
     return (
         <Edit
@@ -22,7 +53,7 @@ export const GroupBadgeEdit = () => {
                 className: styles.content
             }}
         >
-            <Form {...formProps} scrollToFirstError layout="vertical">
+            <Form {...restFormProps} layout="vertical" scrollToFirstError onFinishFailed={handleFinishFailed}>
                 <GroupBadgeTabs activeKey={activeKey} groupBadgeId={id} onChange={setActiveKey} />
             </Form>
         </Edit>

--- a/packages/admin/src/components/entities/group-badges/edit/group-badge-edit.tsx
+++ b/packages/admin/src/components/entities/group-badges/edit/group-badge-edit.tsx
@@ -1,25 +1,13 @@
 import { useState } from 'react';
 import { Edit, useForm } from '@refinedev/antd';
-import { Form, type FormProps } from 'antd';
+import { Form } from 'antd';
 import { type HttpError } from '@refinedev/core';
 
 import type { GroupBadgeEntity } from 'interfaces';
 import { useScreen } from 'shared/providers';
+import { createFormMainTabFinishFailedHandler } from 'shared/utils/create-form-main-tab-finish-failed-handler';
 import { GroupBadgeTabs } from './group-badge-tabs/group-badge-tabs';
 import styles from './group-badge-edit.module.css';
-
-/** Поля вкладки «Основное» (CreateEdit) — см. при map новых вкладок с полями формы */
-const GROUP_BADGE_MAIN_TAB_FIELDS = ['name', 'direction', 'role', 'qr', 'comment'] as const;
-
-const validationFieldTabKey = (fieldName: (string | number)[]): string => {
-    const segment = fieldName[0];
-
-    if (typeof segment === 'string' && (GROUP_BADGE_MAIN_TAB_FIELDS as readonly string[]).includes(segment)) {
-        return '1';
-    }
-
-    return '1';
-};
 
 export const GroupBadgeEdit = () => {
     const { id, formProps, saveButtonProps, form } = useForm<GroupBadgeEntity, HttpError>();
@@ -28,22 +16,11 @@ export const GroupBadgeEdit = () => {
     const [activeKey, setActiveKey] = useState('1');
     const shouldHideFooterActions = !isDesktop && activeKey !== '1';
 
-    const handleFinishFailed: NonNullable<FormProps['onFinishFailed']> = (errorInfo) => {
-        const sorted = [...(errorInfo.errorFields ?? [])].sort((a, b) =>
-            String(a.name?.[0]).localeCompare(String(b.name?.[0]))
-        );
-        const first = sorted.find((field) => field.name?.length);
-        const namePath = first?.name;
-
-        if (namePath?.length) {
-            setActiveKey(validationFieldTabKey(namePath));
-            window.setTimeout(() => {
-                void form.scrollToField(namePath, { behavior: 'smooth', block: 'nearest', focus: true });
-            }, 100);
-        }
-
-        upstreamOnFinishFailed?.(errorInfo);
-    };
+    const handleFinishFailed = createFormMainTabFinishFailedHandler({
+        form,
+        setActiveKey,
+        upstream: upstreamOnFinishFailed
+    });
 
     return (
         <Edit

--- a/packages/admin/src/components/entities/vols/create.tsx
+++ b/packages/admin/src/components/entities/vols/create.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 import { Create, useForm } from '@refinedev/antd';
-import { Form } from 'antd';
+import { Form, type FormProps } from 'antd';
 
 import type { VolEntity } from 'interfaces';
 
 import { useScreen } from 'shared/providers';
 import CreateEdit from './common';
 import useSaveConfirm from './use-save-confirm';
+import { createVolunteerFormFinishFailedHandler } from './vol-form-finish-failed';
 
 const contentStyle = {
     background: 'initial',
@@ -25,6 +26,13 @@ export const VolCreate = () => {
 
     const { isDesktop } = useScreen();
     const [activeKey, setActiveKey] = useState('1');
+
+    const { onFinishFailed: upstreamOnFinishFailed, ...restFormProps } = formProps;
+    const handleFinishFailed: NonNullable<FormProps['onFinishFailed']> = createVolunteerFormFinishFailedHandler(
+        setActiveKey,
+        form,
+        upstreamOnFinishFailed
+    );
     const shouldHideFooterActions = !isDesktop && activeKey !== '1';
 
     return (
@@ -41,7 +49,7 @@ export const VolCreate = () => {
                 style: contentStyle
             }}
         >
-            <Form {...formProps} scrollToFirstError layout="vertical">
+            <Form {...restFormProps} scrollToFirstError layout="vertical" onFinishFailed={handleFinishFailed}>
                 <CreateEdit activeKey={activeKey} setActiveKey={setActiveKey} />
             </Form>
             {renderModal()}

--- a/packages/admin/src/components/entities/vols/edit.tsx
+++ b/packages/admin/src/components/entities/vols/edit.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 import { Link } from 'react-router';
 import { Edit, useForm } from '@refinedev/antd';
 import { useBreadcrumb } from '@refinedev/core';
-import { Form, Breadcrumb } from 'antd';
+import { Form, Breadcrumb, type FormProps } from 'antd';
 import { useLocation, useNavigate } from 'react-router';
 
 import { useScreen } from 'shared/providers';
@@ -10,6 +10,7 @@ import { useLocalStorage } from 'shared/hooks';
 import type { VolEntity } from 'interfaces';
 import CreateEdit from './common';
 import useSaveConfirm from './use-save-confirm';
+import { createVolunteerFormFinishFailedHandler } from './vol-form-finish-failed';
 
 import styles from './common.module.css';
 
@@ -60,6 +61,13 @@ export const VolEdit = () => {
     const { isDesktop } = useScreen();
 
     const [activeKey, setActiveKey] = useState('1');
+
+    const { onFinishFailed: upstreamOnFinishFailed, ...restFormProps } = formProps;
+    const handleFinishFailed: NonNullable<FormProps['onFinishFailed']> = createVolunteerFormFinishFailedHandler(
+        setActiveKey,
+        form,
+        upstreamOnFinishFailed
+    );
     const shouldHideFooterActions = !isDesktop && activeKey !== '1';
 
     const name = Form.useWatch('name', form);
@@ -111,7 +119,7 @@ export const VolEdit = () => {
                 style: contentStyle
             }}
         >
-            <Form {...formProps} scrollToFirstError layout="vertical">
+            <Form {...restFormProps} scrollToFirstError layout="vertical" onFinishFailed={handleFinishFailed}>
                 <CreateEdit activeKey={activeKey} setActiveKey={setActiveKey} />
             </Form>
             {renderModal()}

--- a/packages/admin/src/components/entities/vols/vol-form-finish-failed.ts
+++ b/packages/admin/src/components/entities/vols/vol-form-finish-failed.ts
@@ -1,23 +1,8 @@
 import type { FormInstance, FormProps } from 'antd';
 
-/** Все поля анкеты волонтёра сейчас на первой вкладке (см. `common.tsx` — «Основное»). */
-const VOLUNTEER_FORM_MAIN_TAB_KEY = '1';
+import { createFormMainTabFinishFailedHandler } from 'shared/utils/create-form-main-tab-finish-failed-handler';
 
+/** Все поля анкеты волонтёра сейчас на первой вкладке (см. `common.tsx` — «Основное»). */
 export const createVolunteerFormFinishFailedHandler =
     (setActiveKey: (key: string) => void, form: FormInstance, upstream?: FormProps['onFinishFailed']) =>
-    (errorInfo: Parameters<NonNullable<FormProps['onFinishFailed']>>[0]) => {
-        const sorted = [...(errorInfo.errorFields ?? [])].sort((a, b) =>
-            JSON.stringify(a.name).localeCompare(JSON.stringify(b.name))
-        );
-        const first = sorted.find((field) => field.name?.length);
-        const namePath = first?.name;
-
-        if (namePath?.length) {
-            setActiveKey(VOLUNTEER_FORM_MAIN_TAB_KEY);
-            window.setTimeout(() => {
-                void form.scrollToField(namePath, { behavior: 'smooth', block: 'nearest', focus: true });
-            }, 100);
-        }
-
-        upstream?.(errorInfo);
-    };
+        createFormMainTabFinishFailedHandler({ form, setActiveKey, upstream });

--- a/packages/admin/src/components/entities/vols/vol-form-finish-failed.ts
+++ b/packages/admin/src/components/entities/vols/vol-form-finish-failed.ts
@@ -1,0 +1,23 @@
+import type { FormInstance, FormProps } from 'antd';
+
+/** Все поля анкеты волонтёра сейчас на первой вкладке (см. `common.tsx` — «Основное»). */
+const VOLUNTEER_FORM_MAIN_TAB_KEY = '1';
+
+export const createVolunteerFormFinishFailedHandler =
+    (setActiveKey: (key: string) => void, form: FormInstance, upstream?: FormProps['onFinishFailed']) =>
+    (errorInfo: Parameters<NonNullable<FormProps['onFinishFailed']>>[0]) => {
+        const sorted = [...(errorInfo.errorFields ?? [])].sort((a, b) =>
+            JSON.stringify(a.name).localeCompare(JSON.stringify(b.name))
+        );
+        const first = sorted.find((field) => field.name?.length);
+        const namePath = first?.name;
+
+        if (namePath?.length) {
+            setActiveKey(VOLUNTEER_FORM_MAIN_TAB_KEY);
+            window.setTimeout(() => {
+                void form.scrollToField(namePath, { behavior: 'smooth', block: 'nearest', focus: true });
+            }, 100);
+        }
+
+        upstream?.(errorInfo);
+    };

--- a/packages/admin/src/shared/utils/create-form-main-tab-finish-failed-handler.ts
+++ b/packages/admin/src/shared/utils/create-form-main-tab-finish-failed-handler.ts
@@ -1,0 +1,31 @@
+import type { FormInstance, FormProps } from 'antd';
+
+/**
+ * При ошибке валидации переключает на вкладку с полями формы и прокручивает к первому полю с ошибкой.
+ * Удобно, когда ошибки возможны только на одной вкладке (ключ по умолчанию «1»).
+ */
+export const createFormMainTabFinishFailedHandler = (params: {
+    form: FormInstance;
+    mainTabKey?: string;
+    setActiveKey: (key: string) => void;
+    upstream?: FormProps['onFinishFailed'];
+}): NonNullable<FormProps['onFinishFailed']> => {
+    const { form, mainTabKey = '1', setActiveKey, upstream } = params;
+
+    return (errorInfo) => {
+        const sorted = [...(errorInfo.errorFields ?? [])].sort((a, b) =>
+            JSON.stringify(a.name).localeCompare(JSON.stringify(b.name))
+        );
+        const first = sorted.find((field) => field.name?.length);
+        const namePath = first?.name;
+
+        if (namePath?.length) {
+            setActiveKey(mainTabKey);
+            window.setTimeout(() => {
+                void form.scrollToField(namePath, { behavior: 'smooth', block: 'nearest', focus: true });
+            }, 100);
+        }
+
+        upstream?.(errorInfo);
+    };
+};


### PR DESCRIPTION
Title:
fix(admin): переход на вкладку с ошибкой валидации (групповой бейдж, волонтёр)

Description:

При сохранении формы с другой активной вкладки ошибки Ant Design оставались на «Основное», и пользователь не получал обратной связи.

Групповой бейдж: обработчик onFinishFailed переключает на вкладку «Основное» и делает scrollToField для первого поля с ошибкой.
Волонтёр (создание и редактирование): то же поведение; общая логика вынесена в vol-form-finish-failed.ts.