### PR TITLE
fix: restore page scroll outside volunteer card routes

### DIFF
--- a/docs/volunteers.md
+++ b/docs/volunteers.md
@@ -245,7 +245,9 @@
 Код прежнего UI лежит в `legacy/` и не развивается — это временный запасной выход до
 стабилизации новой карточки.
 
-Файлы: `components/layout/authenticated-app-layout.tsx` (баннер над всем layout),
+Файлы: `components/layout/authenticated-app-layout.tsx` (баннер и viewport-shell только
+на `/volunteers/create` и `/volunteers/edit/:id`; остальные страницы — обычный скролл
+документа),
 `edit.tsx` / `create.tsx` (обёртка), `vol-edit-new.tsx` / `vol-create-new.tsx`
 (новый UI), `legacy/*` (снимок с `main`), `volunteer-card-legacy-ui.ts`,
 `volunteer-card-ui-switch.tsx`, `volunteer-card-ui-banner-context.tsx`.

--- a/packages/admin/src/components/layout/authenticated-app-layout.module.css
+++ b/packages/admin/src/components/layout/authenticated-app-layout.module.css
@@ -1,4 +1,4 @@
-.appLayout,
+/* Viewport-constrained shell only for volunteer create/edit (internal tab scroll). */
 .appLayoutWithBanner {
     display: flex;
     flex-direction: column;

--- a/packages/admin/src/components/layout/authenticated-app-layout.tsx
+++ b/packages/admin/src/components/layout/authenticated-app-layout.tsx
@@ -13,19 +13,25 @@ const isVolunteerCardRoute = (pathname: string) => /^\/volunteers\/(create|edit\
 export const AuthenticatedAppLayout = () => {
     const location = useLocation();
     const legacyUiEnabled = useVolunteerCardLegacyUi();
-    const showVolunteerCardBanner = isVolunteerCardRoute(location.pathname);
-    const bannerMode = showVolunteerCardBanner ? (legacyUiEnabled ? 'legacy' : 'new') : null;
+    const isCardRoute = isVolunteerCardRoute(location.pathname);
+    const bannerMode = isCardRoute ? (legacyUiEnabled ? 'legacy' : 'new') : null;
+
+    const layout = (
+        <ThemedLayout Sider={() => <CustomSider />}>
+            <Outlet />
+        </ThemedLayout>
+    );
 
     return (
         <VolunteerCardUiBannerProvider>
-            <div className={bannerMode ? styles.appLayoutWithBanner : styles.appLayout}>
-                {bannerMode ? <VolunteerCardUiTopBanner mode={bannerMode} /> : null}
-                <div className={styles.appLayoutBody}>
-                    <ThemedLayout Sider={() => <CustomSider />}>
-                        <Outlet />
-                    </ThemedLayout>
+            {isCardRoute && bannerMode ? (
+                <div className={styles.appLayoutWithBanner}>
+                    <VolunteerCardUiTopBanner mode={bannerMode} />
+                    <div className={styles.appLayoutBody}>{layout}</div>
                 </div>
-            </div>
+            ) : (
+                layout
+            )}
         </VolunteerCardUiBannerProvider>
     );
 };


### PR DESCRIPTION
Viewport-constrained layout was applied to all admin pages, hiding pagination and breaking vertical scroll on short screens.